### PR TITLE
KNIFE_WINDOWS-17 WinRm Detects the need for NTLM Authentication

### DIFF
--- a/lib/chef/knife/winrm.rb
+++ b/lib/chef/knife/winrm.rb
@@ -99,12 +99,19 @@ class Chef
           session_opts[:ca_trust_path] = Chef::Config[:knife][:ca_trust_file] if Chef::Config[:knife][:ca_trust_file]
           session_opts[:operation_timeout] = 1800 # 30 min OperationTimeout for long bootstraps fix for KNIFE_WINDOWS-8
 
+          ## If you have a \\ in your name you need to use NTLM domain authentication
+          if session_opts[:user].split("\\").length.eql?(2)
+            session_opts[:basic_auth_only] = false
+          else
+            session_opts[:basic_auth_only] = true
+          end
+
           if config.keys.any? {|k| k.to_s =~ /kerberos/ }
             session_opts[:transport] = :kerberos
             session_opts[:basic_auth_only] = false
           else
             session_opts[:transport] = (Chef::Config[:knife][:winrm_transport] || config[:winrm_transport]).to_sym
-            session_opts[:basic_auth_only] = true
+            session_opts[:disable_sspi] = true
           end
 
           session.use(item, session_opts)


### PR DESCRIPTION
@schisamo Knife winrm will currently only work with basic authentication which means that you are unable to authenticate with domain accounts. There are two things going on in this pull request.

If the user specified a username with a \ in it, assume that they are doing domain authentication and set basic to false. Basic will be set to true when a \ is not detected in the users name.
In order for this to work, https://github.com/schisamo/em-winrm/pull/4 needs to be pulled and closed.

Negotiate will mess up if you have gssapi install and negotiate enabled, but have an unsupported or broken implementation of gssapi. So if you are specifying credentials, clearly you do not want to do kerberos authentication, so disable it and your troubles will go away.
There is an open pull request on WinRM to provide an option to disable Gssapi in the negotiation stack. It does not need to be closed prior accepting this pull request as the added option will only help when your kerberos environment is funky. https://github.com/zenchild/WinRM/pull/19
