### PR TITLE
[KNIFE-18] Adding quotes around the path should solve the problem. 

### DIFF
--- a/lib/chef/knife/bootstrap/windows-shell.erb
+++ b/lib/chef/knife/bootstrap/windows-shell.erb
@@ -33,7 +33,7 @@ copy %TEMP%\rubydevkit.exe C:\DevKit
 cmd.exe /C C:\DevKit\rubydevkit.exe -y
 
 @rem update path during bootstrap session
-SET PATH=%PATH%;C:\ruby\bin
+SET PATH="%PATH%;C:\ruby\bin"
 
 cmd.exe /C ruby c:/DevKit/dk.rb init
 cmd.exe /C ruby c:/DevKit/dk.rb install


### PR DESCRIPTION
https://tickets.opscode.com/browse/KNIFE-18

http://superuser.com/questions/119610/spaces-and-parenthesis-in-windows-path-variable-screws-up-batch-files
