### PR TITLE
[KNIFE-9] Include mingw\bin to the PATH when bootstrapping to build native gems

### DIFF
--- a/lib/chef/knife/core/windows_bootstrap_context.rb
+++ b/lib/chef/knife/core/windows_bootstrap_context.rb
@@ -79,7 +79,7 @@ CONFIG
         end
 
         def start_chef
-          start_chef = "SET \"PATH=%PATH%;C:\\ruby\\bin;C:\\opscode\\chef\\bin;C:\\opscode\\chef\\embedded\\bin\"\n"
+          start_chef = "SET \"PATH=%PATH%;C:\\ruby\\bin;C:\\opscode\\chef\\bin;C:\\opscode\\chef\\embedded\\bin;C:\\opscode\\chef\\embedded\\mingw\\bin\"\n"
           start_chef << "chef-client -c c:/chef/client.rb -j c:/chef/first-boot.json -E #{bootstrap_environment}\n"
         end
 


### PR DESCRIPTION
https://tickets.opscode.com/browse/KNIFE-9

Tested this on my local - windows node bootstrapped and was able to install the "thin" gem during the first run,  without it failed.