### PR TITLE
Qualify module names of EventMachine and WinRM

### DIFF
--- a/lib/chef/knife/winrm.rb
+++ b/lib/chef/knife/winrm.rb
@@ -59,7 +59,7 @@ class Chef
         session_opts = {}
         session_opts[:logger] = Chef::Log.logger if Chef::Log.level == :debug
         @session ||= begin
-          s = EventMachine::WinRM::Session.new(session_opts)
+          s = ::EventMachine::WinRM::Session.new(session_opts)
           s.on_output do |host, data|
             print_data(host, data)
           end
@@ -240,7 +240,7 @@ class Chef
             session.close
             exit @exit_code || 0
           end
-        rescue WinRM::WinRMHTTPTransportError => e
+        rescue ::WinRM::WinRMHTTPTransportError => e
           case e.message
           when /401/
             ui.error "Failed to authenticate to #{@name_args[0].split(" ")} as #{config[:winrm_user]}"


### PR DESCRIPTION
I got module errors on these two lines, since it was trying to resolve Chef::Knife::Winrm:: etc. Qualifying the namespaces fixed winrm bootstrapping for me.
