### PR TITLE
[KNIFE-270] knife bootstrap ssh command fails on Windows target nodes

### DIFF
--- a/lib/chef/knife/bootstrap_windows_base.rb
+++ b/lib/chef/knife/bootstrap_windows_base.rb
@@ -167,7 +167,7 @@ class Chef
       end
 
       def bootstrap_bat_file
-        @bootstrap_bat_file ||= "%TEMP%\\bootstrap-#{Process.pid}-#{Time.now.to_i}.bat"
+        @bootstrap_bat_file ||= "\"%TEMP%\\bootstrap-#{Process.pid}-#{Time.now.to_i}.bat\""
       end
 
       def locate_config_value(key)


### PR DESCRIPTION
http://tickets.opscode.com/browse/KNIFE-270

knife bootstrap ssh command fails on Windows target nodes where the TEMP directory contains spaces; this fixes that issue.
