### PR TITLE
[KNIFE-270] bootstrap for windows node fails when %TEMP% has spaces

### DIFF
--- a/lib/chef/knife/bootstrap_windows_base.rb
+++ b/lib/chef/knife/bootstrap_windows_base.rb
@@ -136,7 +136,7 @@ class Chef
         # we have to run the remote commands in 2047 char chunks
         create_bootstrap_bat_command do |command_chunk, chunk_num|
           begin
-            run_command("cmd.exe /C echo \"Rendering '#{bootstrap_bat_file}' chunk #{chunk_num}\" && #{command_chunk}")
+            run_command("cmd.exe /C echo \"Rendering #{bootstrap_bat_file} chunk #{chunk_num}\" && #{command_chunk}")
           rescue SystemExit => e
             raise unless e.success?
           end
@@ -167,7 +167,7 @@ class Chef
       end
 
       def bootstrap_bat_file
-        @bootstrap_bat_file ||= "%TEMP%\\bootstrap-#{Process.pid}-#{Time.now.to_i}.bat"
+        @bootstrap_bat_file ||= "\"%TEMP%\\bootstrap-#{Process.pid}-#{Time.now.to_i}.bat\""
       end
 
       def locate_config_value(key)


### PR DESCRIPTION
http://tickets.opscode.com/browse/KNIFE-270
