### PR TITLE
[KNIFE-338] Fix bootstrap of 64-bit 2008r2 through FreeSSHd

### DIFF
--- a/lib/chef/knife/bootstrap/windows-chef-client-msi.erb
+++ b/lib/chef/knife/bootstrap/windows-chef-client-msi.erb
@@ -41,26 +41,29 @@ goto Version%WinMajor%.%WinMinor%
 
 @rem If this is an unknown version of windows set the default
 @set MACHINE_OS=2008r2
-goto architecture
+goto architecture_select
 
 :Version6.0
 @set MACHINE_OS=2008
-goto architecture
+goto architecture_select
 
 :Version5.2
 @set MACHINE_OS=2003r2
-goto architecture
+goto architecture_select
 
 :Version6.1
 @set MACHINE_OS=2008r2
-goto architecture
+goto architecture_select
 
 :Version6.2
 @set MACHINE_OS=2012
-goto architecture
+goto architecture_select
 
-:architecture
+:architecture_select
 
+goto Architecture%PROCESSOR_ARCHITEW6432%
+
+:Architecture
 goto Architecture%PROCESSOR_ARCHITECTURE%
 
 @rem If this is an unknown architecture set the default


### PR DESCRIPTION
http://tickets.opscode.com/browse/KNIFE-338

When connecting to FreeSSHd on 20008r2 you get a 32-bit environment. In this environment the PROCESSOR_ARCHITECTURE is reported as i686. This leads to the generation of an invalid URL for downloading the Chef installer.  The workaround is to first check PROCESSOR_ARCHITEW6432 which will show AMD64 even in a 32-bit environment.
