### PR TITLE
Added new command line parameter to specify local WinRM timeout (-T).  D...

### DIFF
--- a/lib/chef/knife/winrm.rb
+++ b/lib/chef/knife/winrm.rb
@@ -113,7 +113,7 @@ class Chef
           session_opts[:realm] = Chef::Config[:knife][:kerberos_realm] if Chef::Config[:knife][:kerberos_realm]
           session_opts[:service] = Chef::Config[:knife][:kerberos_service] if Chef::Config[:knife][:kerberos_service]
           session_opts[:ca_trust_path] = Chef::Config[:knife][:ca_trust_file] if Chef::Config[:knife][:ca_trust_file]
-          session_opts[:operation_timeout] = 1800 # 30 min OperationTimeout for long bootstraps fix for KNIFE_WINDOWS-8
+          session_opts[:operation_timeout] = Chef::Config[:knife][:winrm_timeout]
 
           ## If you have a \\ in your name you need to use NTLM domain authentication
           if session_opts[:user].split("\\").length.eql?(2)

--- a/lib/chef/knife/winrm_base.rb
+++ b/lib/chef/knife/winrm_base.rb
@@ -90,6 +90,13 @@ class Chef
             :description => "The Certificate Authority (CA) trust file used for SSL transport",
             :proc => Proc.new { |trust| Chef::Config[:knife][:ca_trust_file] = trust }
 
+          option :winrm_timeout,
+            :short => "-T TIMEOUT_SECONDS",
+            :long => "--winrm-timeout SECONDS",
+            :description => "The WinRM timeout, by default this is 1800",
+            :default => "1800",
+            :proc => Proc.new { |timeout| Chef::Config[:knife][:winrm_timeout] = timeout }
+
         end
       end
 


### PR DESCRIPTION
...efault is 1800 seconds (previously hard coded value).  This doesn't work when Chef runs take longer than 30 minutes (frequently for us while installing things like MSSQL).
