### PR TITLE
[KNIFE-355] Add --no-ssl-peer-verification option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .bundle
 Gemfile.lock
 pkg/*
+.idea

--- a/knife-windows.gemspec
+++ b/knife-windows.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.description = s.summary
 
   s.required_ruby_version	= ">= 1.9.1"
-  s.add_dependency "em-winrm", "= 0.5.4"
+  s.add_dependency "em-winrm", "= 0.5.5"
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")

--- a/lib/chef/knife/bootstrap/windows-shell.erb
+++ b/lib/chef/knife/bootstrap/windows-shell.erb
@@ -62,7 +62,7 @@ cmd.exe /C gem install chef --no-rdoc --no-ri --verbose <%= bootstrap_version_st
 )
 
 > C:\chef\first-boot.json (
- <%= run_list %>
+ <%= first_boot %>
 )
 
 <%= start_chef %>

--- a/lib/chef/knife/bootstrap/windows-shell.erb
+++ b/lib/chef/knife/bootstrap/windows-shell.erb
@@ -23,11 +23,11 @@ mkdir C:\chef
  <%= win_wget %>
 )
 
-cscript /nologo C:\chef\wget.vbs /url:http://files.rubyforge.vm.bytemark.co.uk/rubyinstaller/rubyinstaller-1.8.7-p334.exe /path:%TEMP%\rubyinstaller.exe
+cscript /nologo C:\chef\wget.vbs /url:http://rubyforge.org/frs/download.php/76952/rubyinstaller-1.9.3-p429.exe /path:%TEMP%\rubyinstaller.exe
 %TEMP%\rubyinstaller.exe /verysilent /dir="C:\ruby" /tasks="assocfiles,modpath"
 
 @rem Install the Ruby Dev Kit so we compile us some native gems
-cscript /nologo C:\chef\wget.vbs /url:http://cloud.github.com/downloads/oneclick/rubyinstaller/DevKit-tdm-32-4.5.1-20101214-1400-sfx.exe /path:%TEMP%\rubydevkit.exe
+cscript /nologo C:\chef\wget.vbs /url:http://cloud.github.com/downloads/oneclick/rubyinstaller/DevKit-tdm-32-4.5.2-20111229-1559-sfx.exe /path:%TEMP%\rubydevkit.exe
 mkdir C:\DevKit
 copy %TEMP%\rubydevkit.exe C:\DevKit
 cmd.exe /C C:\DevKit\rubydevkit.exe -y
@@ -38,8 +38,9 @@ SET PATH=%PATH%;C:\ruby\bin
 cmd.exe /C ruby c:/DevKit/dk.rb init
 cmd.exe /C ruby c:/DevKit/dk.rb install
 
-cmd.exe /C gem install win32-api win32-service --platform=mswin32
-cmd.exe /C gem install win32-open3 rdp-ruby-wmi windows-api windows-pr --no-rdoc --no-ri --verbose
+cmd.exe /C gem install ffi --no-rdoc --no-ri --verbose
+cmd.exe /C gem install win32-api win32-service --platform=mswin32 --no-rdoc --no-ri --verbose
+cmd.exe /C gem install rdp-ruby-wmi windows-api windows-pr --no-rdoc --no-ri --verbose
 
 @rem Install Chef gems separately to prevent failed to allocate memory errors
 cmd.exe /C gem install ohai --no-rdoc --no-ri --verbose

--- a/lib/chef/knife/bootstrap/windows-shell.erb
+++ b/lib/chef/knife/bootstrap/windows-shell.erb
@@ -41,7 +41,7 @@ cmd.exe /C ruby c:/DevKit/dk.rb install
 cmd.exe /C gem install win32-api win32-service --platform=mswin32
 cmd.exe /C gem install win32-open3 rdp-ruby-wmi windows-api windows-pr --no-rdoc --no-ri --verbose
 
-@rem Install Chef gems separately to prevent 'failed to allocate memory' errors
+@rem Install Chef gems separately to prevent failed to allocate memory errors
 cmd.exe /C gem install ohai --no-rdoc --no-ri --verbose
 cmd.exe /C gem install chef --no-rdoc --no-ri --verbose <%= bootstrap_version_string %>
 
@@ -56,7 +56,7 @@ cmd.exe /C gem install chef --no-rdoc --no-ri --verbose <%= bootstrap_version_st
 <% end -%>
 
 > C:\chef\client.rb (
- echo.require 'win32ole'
+ echo.require "win32ole"
  echo.WIN32OLE.codepage = WIN32OLE::CP_UTF8
  <%= config_content %>
 )

--- a/lib/chef/knife/bootstrap_windows_base.rb
+++ b/lib/chef/knife/bootstrap_windows_base.rb
@@ -148,7 +148,7 @@ class Chef
         # we have to run the remote commands in 2047 char chunks
         create_bootstrap_bat_command do |command_chunk, chunk_num|
           begin
-            run_command("cmd.exe /C echo \"Rendering '#{bootstrap_bat_file}' chunk #{chunk_num}\" && #{command_chunk}")
+            run_command(%Q!cmd.exe /C echo "Rendering #{bootstrap_bat_file} chunk #{chunk_num}" && #{command_chunk}!)
           rescue SystemExit => e
             raise unless e.success?
           end
@@ -169,7 +169,7 @@ class Chef
           # escape WIN BATCH special chars
           line.gsub!(/[(<|>)^]/).each{|m| "^#{m}"}
           # windows commands are limited to 2047 characters
-          if((bootstrap_bat + [line]).join(" && ").size > 2047 )
+          if((bootstrap_bat + [line]).join(" && ").size > 2047)
             yield bootstrap_bat.join(" && "), chunk_num += 1
             bootstrap_bat = []
           end

--- a/lib/chef/knife/bootstrap_windows_base.rb
+++ b/lib/chef/knife/bootstrap_windows_base.rb
@@ -89,6 +89,10 @@ class Chef
             :long => "--secret-file SECRET_FILE",
             :description => "A file containing the secret key to use to encrypt data bag item values. Will be rendered on the node at c:/chef/encrypted_data_bag_secret and set in the rendered client config."
 
+          option :no_ssl_peer_verification,
+            :long => "--no-ssl-peer-verification",
+            :description => "Do not verify the SSL peer's certificate"
+
         end
       end
 

--- a/lib/chef/knife/bootstrap_windows_winrm.rb
+++ b/lib/chef/knife/bootstrap_windows_winrm.rb
@@ -51,6 +51,8 @@ class Chef
         winrm.config[:kerberos_realm] = Chef::Config[:knife][:kerberos_realm] if Chef::Config[:knife][:kerberos_realm]
         winrm.config[:kerberos_service] = Chef::Config[:knife][:kerberos_service] if Chef::Config[:knife][:kerberos_service]
         winrm.config[:ca_trust_file] = Chef::Config[:knife][:ca_trust_file] if Chef::Config[:knife][:ca_trust_file]
+        winrm.config[:no_ssl_peer_verification] = true if config.has_key?(:no_ssl_peer_verification)
+        Chef::Log.debug "config.has_key?(:no_ssl_peer_verification) = #{config.has_key?(:no_ssl_peer_verification)} (#{config[:no_ssl_peer_verification]})"
         winrm.config[:manual] = true
         winrm.config[:winrm_port] = locate_config_value(:winrm_port)
         winrm.run

--- a/lib/chef/knife/core/windows_bootstrap_context.rb
+++ b/lib/chef/knife/core/windows_bootstrap_context.rb
@@ -92,20 +92,20 @@ Set objXMLHTTP = CreateObject("MSXML2.ServerXMLHTTP")
 Set wshShell = CreateObject( "WScript.Shell" )
 Set objUserVariables = wshShell.Environment("USER")
 
-'http proxy is optional
-'attempt to read from HTTP_PROXY env var first
+rem http proxy is optional
+rem attempt to read from HTTP_PROXY env var first
 On Error Resume Next
 
 If NOT (objUserVariables("HTTP_PROXY") = "") Then
 proxy = objUserVariables("HTTP_PROXY")
 
-'fall back to named arg
+rem fall back to named arg
 ElseIf NOT (WScript.Arguments.Named("proxy") = "") Then
 proxy = WScript.Arguments.Named("proxy")
 End If
 
 If NOT isNull(proxy) Then
-'setProxy method is only available on ServerXMLHTTP 6.0+
+rem setProxy method is only available on ServerXMLHTTP 6.0+
 Set objXMLHTTP = CreateObject("MSXML2.ServerXMLHTTP.6.0")
 objXMLHTTP.setProxy 2, proxy
 End If

--- a/lib/chef/knife/core/windows_bootstrap_context.rb
+++ b/lib/chef/knife/core/windows_bootstrap_context.rb
@@ -22,10 +22,10 @@ class Chef
   class Knife
     module Core
       # Instances of BootstrapContext are the context objects (i.e., +self+) for
-      # bootstrap templates. For backwards compatability, they +must+ set the
+      # bootstrap templates. For backwards compatibility, they +must+ set the
       # following instance variables:
       # * @config   - a hash of knife's config values
-      # * @run_list - the run list for the node to boostrap
+      # * @run_list - the run list for the node to bootstrap
       #
       class WindowsBootstrapContext < BootstrapContext
 

--- a/lib/chef/knife/winrm.rb
+++ b/lib/chef/knife/winrm.rb
@@ -113,6 +113,8 @@ class Chef
           session_opts[:realm] = Chef::Config[:knife][:kerberos_realm] if Chef::Config[:knife][:kerberos_realm]
           session_opts[:service] = Chef::Config[:knife][:kerberos_service] if Chef::Config[:knife][:kerberos_service]
           session_opts[:ca_trust_path] = Chef::Config[:knife][:ca_trust_file] if Chef::Config[:knife][:ca_trust_file]
+          session_opts[:no_ssl_peer_verification] = true if config.has_key?(:no_ssl_peer_verification)
+          Chef::Log.debug "config.has_key?(:no_ssl_peer_verification) = #{config.has_key?(:no_ssl_peer_verification)} (#{config[:no_ssl_peer_verification]})"
           session_opts[:operation_timeout] = 1800 # 30 min OperationTimeout for long bootstraps fix for KNIFE_WINDOWS-8
 
           ## If you have a \\ in your name you need to use NTLM domain authentication
@@ -135,6 +137,7 @@ class Chef
             end
           end
 
+          Chef::Log.debug "session_opts[:no_ssl_peer_verification] = #{session_opts[:no_ssl_peer_verification]}"
           session.use(item, session_opts)
 
           @longest = item.length if item.length > @longest

--- a/lib/chef/knife/winrm_base.rb
+++ b/lib/chef/knife/winrm_base.rb
@@ -90,6 +90,10 @@ class Chef
             :description => "The Certificate Authority (CA) trust file used for SSL transport",
             :proc => Proc.new { |trust| Chef::Config[:knife][:ca_trust_file] = trust }
 
+          option :no_ssl_peer_verification,
+            :long => "--no-ssl-peer-verification",
+            :description => "Do not verify the SSL peer's certificate"
+
         end
       end
 


### PR DESCRIPTION
https://tickets.opscode.com/browse/KNIFE-355

This allows WinRM to work over HTTPS, when the target node is using a self-signed cert, or using a certificate that doesn't match the host name, etc.

Works with commits to the WinRM (https://github.com/gswallow/WinRM/commit/f4ece4384df2768bc7756c3c5c336db65b05c674) and em-winrm (https://github.com/gswallow/em-winrm/commit/75eb847c6b2cdf09b6c6e7b4cfa3f69d9c45f47a) gems.