### PR TITLE
KNIFE-354: Fix bootstrap failure for Windows 8.1 and any unknown versions

### DIFF
--- a/lib/chef/knife/bootstrap/windows-chef-client-msi.erb
+++ b/lib/chef/knife/bootstrap/windows-chef-client-msi.erb
@@ -37,10 +37,20 @@ FOR /F "tokens=1-8 delims=.[] " %%A IN ('ver') DO (
 @set WinBuild=%%F
 )
 
+@set LATEST_OS_VERSION_MAJOR=6
+@set LATEST_OS_VERSION_MINOR=3
+
+@if /i %WinMajor% GTR %LATEST_OS_VERSION_MAJOR% goto VersionUnknown
+@if /i %WinMajor% EQU %LATEST_OS_VERSION_MAJOR%  (
+  @if /i %WinMinor% GTR %LATEST_OS_VERSION_MINOR% goto VersionUnknown
+)
+
 goto Version%WinMajor%.%WinMinor%
 
+:VersionUnknown
 @rem If this is an unknown version of windows set the default
 @set MACHINE_OS=2008r2
+@echo Warning: Unknown version of Windows, assuming default of Windows %MACHINE_OS%
 goto architecture
 
 :Version6.0
@@ -58,6 +68,10 @@ goto architecture
 :Version6.2
 @set MACHINE_OS=2012
 goto architecture
+
+@rem Currently Windows Server 2012 R2 is treated as equivalent to Windows Server 2012 
+:Version6.3
+goto Version6.2
 
 :architecture
 


### PR DESCRIPTION
Details of the problem and cause can be found at http://tickets.opscode.com/browse/KNIFE-354.

The issue is caused because the template assumes that "goto" in batch script continues executing the script if the label that the goto specifies does not exist, which is what happens when we encounter an unknown version of Windows such as 6.3. Goto instead terminates the script, not the intent of the code which clearly expects a "fall through" to enable a default of Win2k8R2 for omnitruck url.

The fix here includes adding support for Windows 8.1 / Win2k12 R2 by adding an explicit label for it like the others. That label currently jumps to the existing Win2kR12 (Windows 6.2) case because there is no omnitruck entry for Win2k12R2. 

Additionally, the fallback logic has been explicitly implemented -- we examine the version numbers and assume that they are ordered and that everything below a certain maximum version # is supported (clearly not true for versions below Win2k3r2, but those cases should fail anyway).

If omnitruck gets a Win2k12R2 version, we'll need to update this to support it rather than map to Win2k12. Additionally, when Windows 6.4 or Windows 7.0, etc. are released, we'll need to update the maximum version in the script if we have omnitruck support for those releases, and also add goto labels for them.

Future improvements could include changing omnitruck to use Windows version #'s in the url rather than marketing names to avoid the need for the batch file to perform the mapping, or breaking out the mapping into a separate script that can be injected into the template; the separate script would be much easier to write tests against.

Because Windows 8.1 is scheduled for release very soon, this more tactical approach was chosen.
