### PR TITLE
Fix for the eventmachine gem version issue with knife-windows.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,8 @@ source "https://rubygems.org"
 # Specify your gem's dependencies in knife-windows.gemspec
 gemspec
 
+gem 'em-winrm', :git => 'https://github.com/ClogenyTechnologies/em-winrm.git', :branch => 'prabhu-OC-10390-knife-windows-dependency'
+
 group :test do
   gem "rspec"
   gem "ruby-wmi"

--- a/knife-windows.gemspec
+++ b/knife-windows.gemspec
@@ -15,7 +15,6 @@ Gem::Specification.new do |s|
   s.description = s.summary
 
   s.required_ruby_version	= ">= 1.9.1"
-  s.add_dependency "em-winrm", "= 0.5.4"
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")


### PR DESCRIPTION
I am pointing to the forked Clogenytechnologies/em-winrm and my branch. Once the changes in the em-winrm is merged we can remove the git and branch specifications from here. Kindly review this approach. Thanks
