### PR TITLE
If "knife bootstrap windows winrm" fails authentication, then have a non-zero exit code

### DIFF
--- a/lib/chef/knife/bootstrap_windows_base.rb
+++ b/lib/chef/knife/bootstrap_windows_base.rb
@@ -160,6 +160,7 @@ class Chef
         # execute the bootstrap.bat file
         bootstrap_command_result = run_command(bootstrap_command)
         ui.error("Bootstrap command returned #{bootstrap_command_result}") if bootstrap_command_result != 0
+        throw SystemExit if bootstrap_command_result != 0
         bootstrap_command_result
       end
 

--- a/lib/chef/knife/winrm.rb
+++ b/lib/chef/knife/winrm.rb
@@ -274,6 +274,7 @@ class Chef
           when /401/
             ui.error "Failed to authenticate to #{@name_args[0].split(" ")} as #{config[:winrm_user]}"
             ui.info "Response: #{e.message}"
+            return -1
           else
             raise e
           end


### PR DESCRIPTION
Currently, if we get a "ERROR: Failed to authenticate to ["blah.com"] as Administrator", we still get a zero exit code. This pull request makes those errors cause a -1 exit code
