### PR TITLE
OC-10255 - Add option to use sspi negotiate in winrm.

### DIFF
--- a/lib/chef/knife/winrm.rb
+++ b/lib/chef/knife/winrm.rb
@@ -147,7 +147,8 @@ class Chef
             session_opts[:basic_auth_only] = false
           else
             session_opts[:transport] = (Chef::Config[:knife][:winrm_transport] || config[:winrm_transport]).to_sym
-            session_opts[:disable_sspi] = true
+            session_opts[:transport] == :sspinegotiate ? session_opts[:disable_sspi] = false : session_opts[:disable_sspi] = true
+            
             if session_opts[:user] and
                 (not session_opts[:password])
               session_opts[:password] = Chef::Config[:knife][:winrm_password] = config[:winrm_password] = get_password

--- a/lib/chef/knife/winrm_base.rb
+++ b/lib/chef/knife/winrm_base.rb
@@ -63,7 +63,7 @@ class Chef
           option :winrm_transport,
             :short => "-t TRANSPORT",
             :long => "--winrm-transport TRANSPORT",
-            :description => "The WinRM transport type.  valid choices are [ssl, plaintext]",
+            :description => "The WinRM transport type.  valid choices are [ssl, plaintext, sspinegotiate]",
             :default => 'plaintext',
             :proc => Proc.new { |transport| Chef::Config[:knife][:winrm_transport] = transport }
 


### PR DESCRIPTION
This change helps to enable sspi, which was always disabled. Useful in Winrm ntlm auth fix in OC-10255
