### PR TITLE
Parametrize suppress_auth_failure & report auth failures by default

### DIFF
--- a/lib/chef/knife/bootstrap_windows_base.rb
+++ b/lib/chef/knife/bootstrap_windows_base.rb
@@ -98,6 +98,12 @@ class Chef
             :long => "--auth-timeout MINUTES",
             :description => "The maximum time in minutes to wait to for authentication over the transport to the node to succeed. The default value is 25 minutes.",
             :default => 25
+
+          option :suppress_auth_failure,
+            :long => "--suppress-auth-failure",
+            :description => "Suppress authentication failures when connecting to a target system.",
+            :default => false,
+            :boolean => true
         end
       end
 

--- a/lib/chef/knife/bootstrap_windows_winrm.rb
+++ b/lib/chef/knife/bootstrap_windows_winrm.rb
@@ -53,7 +53,7 @@ class Chef
         winrm.config[:ca_trust_file] = Chef::Config[:knife][:ca_trust_file] if Chef::Config[:knife][:ca_trust_file]
         winrm.config[:manual] = true
         winrm.config[:winrm_port] = locate_config_value(:winrm_port)
-        winrm.config[:suppress_auth_failure] = true
+        winrm.config[:suppress_auth_failure] = locate_config_value(:suppress_auth_failure)
         winrm.config[:returns] = nil
         winrm.run
       end


### PR DESCRIPTION
This would likely be a breaking change, but as of version 0.6.0 of this gem, auth failures are not reported properly and result in a loop of:
Waiting for remote response before bootstrap.DEBUG: Adding <snip_IP>
DEBUG: :session => :init
DEBUG: :relay_to_servers => echo . & echo Response received.
DEBUG: :relayed => <snip_IP>
DEBUG: 172.28.0.85 => :run_command
..DEBUG: Adding <snip_IP>
DEBUG: :session => :init
DEBUG: :relay_to_servers => echo . & echo Response received.
DEBUG: :relayed => <snip_IP>
DEBUG: 172.28.0.85 => :run_command
.

This PR adds a --suppress-auth-failure flag that when passed, emulates the previously default behaviour.
