### PR TITLE
Reduces default timeout from 25 -> 2 minutes

### DIFF
--- a/lib/chef/knife/bootstrap_windows_base.rb
+++ b/lib/chef/knife/bootstrap_windows_base.rb
@@ -96,7 +96,7 @@ class Chef
 
           option :auth_timeout,
             :long => "--auth-timeout MINUTES",
-            :description => "The maximum time in minutes to wait to for authentication over the transport to the node to succeed. The default value is 25 minutes.",
+            :description => "The maximum time in minutes to wait to for authentication over the transport to the node to succeed. The default value is 2 minutes.",
             :default => 2
         end
       end


### PR DESCRIPTION
Pending reciprocal accommodations in knife-ec2 to set "auth_timeout" if the target instance is a windows. Relates to https://github.com/opscode/knife-ec2/pull/222
