### PR TITLE
Update windows_bootstrap_context.rb

### DIFF
--- a/lib/chef/knife/core/windows_bootstrap_context.rb
+++ b/lib/chef/knife/core/windows_bootstrap_context.rb
@@ -149,7 +149,7 @@ WGET_PS
         end
 
         def install_chef
-          install_chef = 'msiexec /qn /log "%CHEF_CLIENT_MSI_LOG_PATH%" /i "%LOCAL_DESTINATION_MSI_PATH%"'
+          install_chef = 'msiexec /qn /log "%CHEF_CLIENT_MSI_LOG_PATH%" /i "%LOCAL_DESTINATION_MSI_PATH%" ADDLOCAL="ChefClientFeature,ChefServiceFeature"'
         end
 
         def bootstrap_directory


### PR DESCRIPTION
During bootstrap the chef-client is not currently set to either run or activate the chef-client service. Adding this bit, 'ADDLOCAL="ChefClientFeature,ChefServiceFeature"' to the end of the installation command on line 152 activates these two Features for windows during install. 