### PR TITLE
Workaround broken OS patch KB2918614

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 None.
 
 ## Latest release: 0.8.0
+* [knife-windows #96](https://github.com/opscode/knife-windows/issues/96) Fix break from OS patch KB2918614
 * Update winrm-s dependency along with em-winrm and winrm dependencies
 * Return failure codes from knife winrm even when `returns` is not set
 * Support Windows negotiate authentication protocol when running knife on Windows


### PR DESCRIPTION
This OS patch is causing the chef-client msi installation on Windows to fail when bootstrapping over winrm. The issue is apparently a regression in Windows Installer:
http://support.microsoft.com/kb/2918614
http://answers.microsoft.com/en-us/windows/forum/windows8_1-windows_install/kb2918614-breaks-windows-installer-service/3d75a1c2-114a-4241-a527-35b536edc158

The workaround here is to detect if there's a failure to install, then use task scheduler to install the msi. Because task scheduler is asynchronous, we use the waitfor command to send a signal when the installation is done, and the bootstrap script waits for it before proceeding to try to run Chef. A downside of this approach is that it is difficult to obtain the return value of the task execution.
