### PR TITLE
Add --use-encryption option for winrm

### DIFF
--- a/lib/chef/knife/winrm.rb
+++ b/lib/chef/knife/winrm.rb
@@ -186,8 +186,9 @@ class Chef
           else
             session_opts[:transport] = (Chef::Config[:knife][:winrm_transport] || config[:winrm_transport]).to_sym
 
-            if Chef::Platform.windows? && config[:use_negotiate_authentication]
-              # windows - force only encrypted communication
+            # :winrm_allow_unencrypted default is 'true'. It becomes 'false' when user specifies.
+            # And by default on windows support only encrypted communication
+            if Chef::Platform.windows? && config[:winrm_allow_unencrypted]
               require 'winrm-s'
               session_opts[:transport] = :sspinegotiate
               session_opts[:disable_sspi] = false
@@ -276,7 +277,7 @@ class Chef
       end
 
       def validate!
-        ui.error "The '--encrypt-winrm-transport' option only supported from Windows Chef Workstation." if config[:use_negotiate_authentication] && !Chef::Platform.windows?
+        ui.error "The '--winrm-allow-unencrypted' option only supported from Windows Chef Workstation." if ! config[:winrm_allow_unencrypted] && !Chef::Platform.windows?
       end
 
       def run
@@ -313,7 +314,7 @@ class Chef
               # Display errors if the caller hasn't opted to retry
               ui.error "Failed to authenticate to #{@name_args[0].split(" ")} as #{config[:winrm_user]}"
               ui.info "Response: #{e.message}"
-              ui.info "Hint: Please check winrm configuration winrm/config/service AllowUnencrypted flag on remote server OR try '--use-negotiate-authentication' option."
+              ui.info "Hint: Please check winrm configuration winrm/config/service AllowUnencrypted flag on remote server OR try '--winrm-allow-unencrypted' option."
               raise e
             end
             @exit_code = 401

--- a/lib/chef/knife/winrm_base.rb
+++ b/lib/chef/knife/winrm_base.rb
@@ -91,11 +91,11 @@ class Chef
             :description => "The Certificate Authority (CA) trust file used for SSL transport",
             :proc => Proc.new { |trust| Chef::Config[:knife][:ca_trust_file] = trust }
 
-          option :use_negotiate_authentication,
-            :long => "--use-negotiate-authentication",
-            :description => "Use negotiate protocol for authentication. It requires 'AllowUnencrypted' set to 'false' on the remote server. The --use-negotiate-authentication option is only supported when this tool is invoked from a Windows-based system. Default is false.",
+          option :winrm_allow_unencrypted,
+            :long => "--winrm-allow-unencrypted",
+            :description => "Use unencrypted communication for WinRM. It requires 'AllowUnencrypted' set to 'true' on the remote server. The '--winrm-allow-unencrypted' option is only supported when this tool is invoked from a Windows-based system. Default is true.",
             :boolean => true,
-            :default => false
+            :default => true
         end
       end
 

--- a/spec/unit/knife/winrm_spec.rb
+++ b/spec/unit/knife/winrm_spec.rb
@@ -164,8 +164,8 @@ describe Chef::Knife::Winrm do
             allow(@winrm).to receive(:relay_winrm_command).and_return(0)
           end
 
-          context "when --use-negotiate-authentication set" do
-            before { @winrm.config[:use_negotiate_authentication] = true }
+          context "when --winrm-allow-unencrypted not specified (i.e default)" do
+            before { @winrm.config[:winrm_allow_unencrypted] = true }
             it "should have winrm opts transport set to sspinegotiate for windows" do
               @winrm.config[:winrm_user] = "domain\\testuser"
               allow(Chef::Platform).to receive(:windows?).and_return(true)
@@ -203,8 +203,8 @@ describe Chef::Knife::Winrm do
             end
           end
 
-          context "when --use-negotiate-authentication not set (i.e default)" do
-            before { @winrm.config[:use_negotiate_authentication] = false }
+          context "when --winrm-allow-unencrypted specified" do
+            before { @winrm.config[:winrm_allow_unencrypted] = false }
             it "should skip winrm monkey patch for windows" do
               @winrm.config[:winrm_user] = "testuser"
               allow(Chef::Platform).to receive(:windows?).and_return(true)
@@ -214,8 +214,8 @@ describe Chef::Knife::Winrm do
             end
           end
 
-          context "when --use-negotiate-authentication set on Linux Chef Workstation" do
-            before { @winrm.config[:use_negotiate_authentication] = true }
+          context "when --winrm-allow-unencrypted specified on Linux Chef Workstation" do
+            before { @winrm.config[:winrm_allow_unencrypted] = false }
             it "should raise error" do
               @winrm.config[:winrm_user] = "testuser"
               allow(Chef::Platform).to receive(:windows?).and_return(false)


### PR DESCRIPTION
@adamedx  @NimishaS  @kaustubh-d 

Added changes for --use-encryption option. It will decide use of 'winrm-s' patch for winrm communication.
