### PR TITLE
Adding knife wsman test to validate WSMAN/WinRM availability

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,5 +12,6 @@ gem 'winrm-s', github: 'chef/winrm-s'
 group :test do
   gem "rspec", '~> 3.0'
   gem "ruby-wmi"
+  gem "httpclient"
   gem 'rake'
 end

--- a/README.md
+++ b/README.md
@@ -47,11 +47,18 @@ This subcommand operates in a manner similar to [knife ssh](https://docs.chef.io
 ### knife wsman test
 
 Connects to the remote WSMan/WinRM endpoint and verifies the remote node is listening.  This is the equivalent of running Test-Wsman from PowerShell.  Endpoints to test can be specified manually, or be driven by search and use many of the same connection options as knife winrm.
+To test a single node using the default WinRM port (5985)
 
     knife wsman test 192.168.1.10 -m
-or
+
+or to test a single node with SSL enabled on the default port (5986)
+
+    knife wsman test 192.168.1.10 -m --winrm-transport ssl
+
+or to test all windows nodes registered with your Chef Server organization
 
     knife wsman test platform:windows
+
 
 ### knife bootstrap windows winrm
 
@@ -61,7 +68,7 @@ This subcommand operates in a manner similar to [knife bootstrap](https://docs.c
 
     knife bootstrap windows winrm ec2-50-xx-xx-124.compute-1.amazonaws.com -r 'role[webserver],role[production]' -x Administrator -P 'super_secret_password'
 
-### Use SSL for WinRM communication 
+### Use SSL for WinRM communication
 
 By default, the `knife winrm` and `knife bootstrap windows winrm` subcommands use a plaintext transport,
 but they support an option `--winrm-transport` (or `-t`) with the argument

--- a/README.md
+++ b/README.md
@@ -44,6 +44,15 @@ Or force a chef run:
 
 This subcommand operates in a manner similar to [knife ssh](https://docs.chef.io/knife_ssh.html)...just leveraging the WinRM protocol for communication. It also include's `knife ssh`'s "[interactive session mode](https://docs.chef.io/knife_ssh.html#options)"
 
+### knife wsman test
+
+Connects to the remote WSMan/WinRM endpoint and verifies the remote node is listening.  This is the equivalent of running Test-Wsman from PowerShell.  Endpoints to test can be specified manually, or be driven by search and use many of the same connection options as knife winrm.
+
+    knife wsman test 192.168.1.10 -m
+or
+
+    knife wsman test platform:windows
+
 ### knife bootstrap windows winrm
 
 Performs a Chef Bootstrap (via the WinRM protocol) on the target node. The goal of the bootstrap is to get Chef installed on the target system so it can run Chef Client with a Chef Server. The main assumption is a baseline OS installation exists. It is primarily intended for Chef Client systems that talk to a Chef server.

--- a/knife-windows.gemspec
+++ b/knife-windows.gemspec
@@ -15,7 +15,8 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version	= ">= 1.9.1"
   s.add_dependency "winrm", "~> 1.3"
-  s.add_dependency "winrm-s", "~> 0.2"
+  s.add_dependency "winrm-s", "~> 0.3.0.dev.0"
+  s.add_dependency "nokogiri"
 
 
   s.add_development_dependency 'pry'
@@ -26,3 +27,4 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 end
+

--- a/lib/chef/knife/windows_helper.rb
+++ b/lib/chef/knife/windows_helper.rb
@@ -20,6 +20,7 @@ require 'chef/knife'
 require 'chef/knife/winrm'
 require 'chef/knife/bootstrap_windows_ssh'
 require 'chef/knife/bootstrap_windows_winrm'
+require 'chef/knife/wsman_test'
 
 class Chef
   class Knife
@@ -27,7 +28,8 @@ class Chef
 
       banner "#{BootstrapWindowsWinrm.banner}\n" +
               "#{BootstrapWindowsSsh.banner}\n" +
-              "#{Winrm.banner}"
+              "#{Winrm.banner}\n" +
+              "#{WsmanTest.banner}" 
     end
   end
 end

--- a/lib/chef/knife/winrm.rb
+++ b/lib/chef/knife/winrm.rb
@@ -17,332 +17,42 @@
 #
 
 require 'chef/knife'
-require 'chef/knife/winrm_base'
+require 'chef/knife/winrm_knife_base'
 require 'chef/knife/windows_cert_generate'
 require 'chef/knife/windows_cert_install'
 require 'chef/knife/windows_listener_create'
+require 'chef/knife/winrm_session'
 
 class Chef
   class Knife
-    class Winrm < Knife
+    class Winrm < Knife 
 
-      @@ssl_warning_given = false
-
-      class Session
-        attr_reader :host, :output, :error, :exit_code
-        def initialize(options)
-          @host = options[:host]
-          url = "#{options[:host]}:#{options[:port]}/wsman"
-          scheme = options[:transport] == :ssl ? 'https' : 'http'
-          endpoint = "#{scheme}://#{url}"
-          opts = Hash.new
-          opts = {:user => options[:user], :pass => options[:password], :basic_auth_only => options[:basic_auth_only], :disable_sspi => options[:disable_sspi], :no_ssl_peer_verification => options[:no_ssl_peer_verification]}
-
-          options[:transport] == :kerberos ? opts.merge!({:service => options[:service], :realm => options[:realm], :keytab => options[:keytab]}) : opts.merge!({:ca_trust_path => options[:ca_trust_path]})
-          Chef::Log.debug("WinRM::WinRMWebService options: #{opts}")
-          Chef::Log.debug("Endpoint: #{endpoint}")
-          Chef::Log.debug("Transport: #{options[:transport]}")
-          @winrm_session = WinRM::WinRMWebService.new(endpoint, options[:transport], opts)
-          @winrm_session.set_timeout(options[:operation_timeout]) if options[:operation_timeout]
-        end
-
-        def relay_command(command)
-          remote_id = @winrm_session.open_shell
-          command_id = @winrm_session.run_command(remote_id, command)
-          Chef::Log.debug("#{@host}[#{remote_id}] => :run_command[#{command}]")
-          session_result = get_output(remote_id, command_id)
-          @winrm_session.cleanup_command(remote_id, command_id)
-          Chef::Log.debug("#{@host}[#{remote_id}] => :command_cleanup[#{command}]")
-          @exit_code = session_result[:exitcode]
-          @winrm_session.close_shell(remote_id)
-          Chef::Log.debug("#{@host}[#{remote_id}] => :shell_close")
-        end
-
-        def get_output(remote_id, command_id)
-          @winrm_session.get_command_output(remote_id, command_id) do |out,error|
-            print_data(@host, out) if out
-            print_data(@host, error, :red) if error
-          end
-        end
-
-        def print_data(host, data, color = :cyan)
-          if data =~ /\n/
-            data.split(/\n/).each { |d| print_data(host, d, color) }
-          elsif !data.nil?
-            print Chef::Knife::Winrm.ui.color(host, color)
-            puts " #{data}"
-          end
-        end
-      end
-
-      include Chef::Knife::WinrmBase
+      include Chef::Knife::WinrmCommandSharedFunctions     
 
       deps do
         require 'readline'
         require 'chef/search/query'
-        require 'winrm'
       end
 
       attr_writer :password
 
-      banner "knife winrm QUERY COMMAND (options)"
-
-      option :attribute,
-        :short => "-a ATTR",
-        :long => "--attribute ATTR",
-        :description => "The attribute to use for opening the connection - default is fqdn",
-        :default => "fqdn"
+      banner "knife winrm QUERY COMMAND (options)"      
 
       option :returns,
        :long => "--returns CODES",
        :description => "A comma delimited list of return codes which indicate success",
-       :default => "0"
-
-      option :manual,
-        :short => "-m",
-        :long => "--manual-list",
-        :boolean => true,
-        :description => "QUERY is a space separated list of servers",
-        :default => false
-
-      def create_winrm_session(options={})
-        session = Chef::Knife::Winrm::Session.new(options)
-        @winrm_sessions ||= []
-        @winrm_sessions.push(session)
-      end
-
-
-      def relay_winrm_command(command)
-        Chef::Log.debug(command)
-        @winrm_sessions.each do |s|
-          s.relay_command(command)
-        end
-      end
-
-      def success_return_codes
-        #Redundant if the CLI options parsing occurs
-        return [0] unless config[:returns]
-        return config[:returns].split(',').collect {|item| item.to_i}
-      end
-
-      # TODO: Copied from Knife::Core:GenericPresenter. Should be extracted
-      def extract_nested_value(data, nested_value_spec)
-        nested_value_spec.split(".").each do |attr|
-          if data.nil?
-            nil # don't get no method error on nil
-          elsif data.respond_to?(attr.to_sym)
-            data = data.send(attr.to_sym)
-          elsif data.respond_to?(:[])
-            data = data[attr]
-          else
-            data = begin
-                     data.send(attr.to_sym)
-                   rescue NoMethodError
-                     nil
-                   end
-          end
-        end
-        ( !data.kind_of?(Array) && data.respond_to?(:to_hash) ) ? data.to_hash : data
-      end
-
-      def configure_session
-
-        list = case config[:manual]
-               when true
-                 @name_args[0].split(" ")
-               when false
-                 r = Array.new
-                 q = Chef::Search::Query.new
-                 @action_nodes = q.search(:node, @name_args[0])[0]
-                 @action_nodes.each do |item|
-                   i = extract_nested_value(item, config[:attribute])
-                   r.push(i) unless i.nil?
-                 end
-                 r
-               end
-        if list.length == 0
-          if @action_nodes.length == 0
-            ui.fatal("No nodes returned from search!")
-          else
-            ui.fatal("#{@action_nodes.length} #{@action_nodes.length > 1 ? "nodes":"node"} found, " +
-                     "but does not have the required attribute (#{config[:attribute]}) to establish the connection. " +
-                     "Try setting another attribute to open the connection using --attribute.")
-          end
-          exit 10
-        end
-        session_from_list(list)
-      end
-
-      def session_from_list(list)
-        list.each do |item|
-          Chef::Log.debug("Adding #{item}")
-          session_opts = {}
-          session_opts[:user] = locate_config_value(:winrm_user)
-          session_opts[:password] = locate_config_value(:winrm_password)
-          session_opts[:port] = locate_config_value(:winrm_port)
-          session_opts[:keytab] = locate_config_value(:kerberos_keytab_file) if locate_config_value(:kerberos_keytab_file)
-          session_opts[:realm] = locate_config_value(:kerberos_realm) if locate_config_value(:kerberos_realm)
-          session_opts[:service] = locate_config_value(:kerberos_service) if locate_config_value(:kerberos_service)
-          session_opts[:ca_trust_path] = locate_config_value(:ca_trust_file) if locate_config_value(:ca_trust_file)
-          #30 min (Default) OperationTimeout for long bootstraps fix for KNIFE_WINDOWS-8
-          session_opts[:operation_timeout] = locate_config_value(:session_timeout).to_i * 60 if locate_config_value(:session_timeout)
-          session_opts[:no_ssl_peer_verification] = no_ssl_peer_verification?(session_opts[:ca_trust_path])
-          warn_no_ssl_peer_verification if session_opts[:no_ssl_peer_verification]
-
-          if locate_config_value(:winrm_authentication_protocol) == "basic"
-            session_opts[:basic_auth_only] = true
-          else
-            session_opts[:basic_auth_only] = false
-          end
-
-          if config.keys.any? {|k| k.to_s =~ /kerberos/ }
-            session_opts[:transport] = :kerberos
-          else
-            session_opts[:transport] = locate_config_value(:winrm_transport).to_sym
-
-            if Chef::Platform.windows? && session_opts[:transport] == :plaintext && negotiate_auth?
-              # windows - force only encrypted communication
-              load_windows_specific_gems
-              session_opts[:transport] = :sspinegotiate
-              session_opts[:disable_sspi] = false
-              Chef::Log.debug("Applied 'winrm-s' monkey patch and trying WinRM communication with 'sspinegotiate'")
-            elsif session_opts[:transport] == :ssl && negotiate_auth?
-              session_opts[:disable_sspi] = true
-              Chef::Log.debug("Trying WinRM communication with negotiate authentication and :ssl transport")
-            else
-              session_opts[:disable_sspi] = true
-            end
-
-            if session_opts[:user] and
-                (not session_opts[:password])
-              session_opts[:password] = Chef::Config[:knife][:winrm_password] = config[:winrm_password] = get_password
-            end
-          end
-
-          session_opts[:host] = item
-          create_winrm_session(session_opts)
-        end
-        end
-
-      def load_windows_specific_gems
-        require 'winrm-s'
-      end
-      def get_password
-        @password ||= ui.ask("Enter your password: ") { |q| q.echo = false }
-      end
-
-      # Present the prompt and read a single line from the console. It also
-      # detects ^D and returns "exit" in that case. Adds the input to the
-      # history, unless the input is empty. Loops repeatedly until a non-empty
-      # line is input.
-      def read_line
-        loop do
-          command = reader.readline("#{ui.color('knife-winrm>', :bold)} ", true)
-
-          if command.nil?
-            command = "exit"
-            puts(command)
-          else
-            command.strip!
-          end
-
-          unless command.empty?
-            return command
-          end
-        end
-      end
-
-      def reader
-        Readline
-      end
-
-      def interactive
-        puts "WARN: Deprecated functionality. This will not be supported in future knife-windows releases."
-        puts "Connected to #{ui.list(session.servers.collect { |s| ui.color(s.host, :cyan) }, :inline, " and ")}"
-        puts
-        puts "To run a command on a list of servers, do:"
-        puts "  on SERVER1 SERVER2 SERVER3; COMMAND"
-        puts "  Example: on latte foamy; echo foobar"
-        puts
-        puts "To exit interactive mode, use 'quit!'"
-        puts
-        while 1
-          command = read_line
-          case command
-          when 'quit!'
-            puts 'Bye!'
-            break
-          when /^on (.+?); (.+)$/
-            raw_list = $1.split(" ")
-            server_list = Array.new
-            @winrm_sessions.each do |session_server|
-              server_list << session_server if raw_list.include?(session_server.host)
-            end
-            command = $2
-            relay_winrm_command(command, server_list)
-          else
-            relay_winrm_command(command)
-          end
-        end
-      end
-
-      # returns true if winrm_authentication_protocol is 'negotiate'
-      def negotiate_auth?
-        locate_config_value(:winrm_authentication_protocol) == "negotiate"
-      end
-
-      def set_defaults
-        transport = locate_config_value(:winrm_transport)
-
-        # set default winrm_port = 5986 for ssl transport
-        # set default winrm_port = 5985 for plaintext transport
-        if transport == 'ssl'
-          Chef::Config[:knife][:winrm_port] = "5986"
-        elsif transport == 'plaintext'
-          Chef::Config[:knife][:winrm_port] = "5985"
-        end if locate_config_value(:winrm_port).nil?
-      end
-
-      def validate!
-        winrm_auth_protocol = locate_config_value(:winrm_authentication_protocol)
-        if winrm_auth_protocol && ! WINRM_AUTH_PROTOCOL_LIST.include?(winrm_auth_protocol)
-          ui.error "Invalid value '#{winrm_auth_protocol}' for --winrm-authentication-protocol option."
-          ui.info "Valid values are #{WINRM_AUTH_PROTOCOL_LIST.join(",")}."
-          exit 1
-        end
-
-        winrm_transport = locate_config_value(:winrm_transport)
-
-        if !Chef::Platform.windows? && negotiate_auth? && winrm_transport == "plaintext"
-          ui.warn "The '--winrm-authentication-protocol = negotiate' with 'plaintext' transport is only supported when this tool is invoked from a Windows-based system."
-          ui.info "Try '--winrm-authentication-protocol = basic'"
-          exit 1
-        end
-      end
-
-      def check_for_errors!
-        @winrm_sessions.each do |session|
-          session_exit_code = session.exit_code
-          unless success_return_codes.include? session_exit_code.to_i
-            @exit_code = session_exit_code.to_i
-            ui.error "Failed to execute command on #{session.host} return code #{session_exit_code}"
-          end
-        end
-      end
+       :default => "0"      
 
       def run
+        STDOUT.sync = STDERR.sync = true        
 
-        STDOUT.sync = STDERR.sync = true
+        configure_session
+        validate_password
+        execute_remote_command        
+      end
 
-        set_defaults
-
-        validate!
-
+      def execute_remote_command
         begin
-          @longest = 0
-
-          configure_session
-
           case @name_args[1]
           when "interactive"
             interactive
@@ -376,31 +86,105 @@ class Chef
         end
       end
 
-      private
-
-      def no_ssl_peer_verification?(ca_trust_path)
-        ca_trust_path.nil? && (config[:winrm_ssl_verify_mode] == :verify_none)
-      end
-
-      def warn_no_ssl_peer_verification
-        if ! @@ssl_warning_given
-          @@ssl_warning_given = true
-          ui.warn(<<-WARN)
-* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
-SSL validation of HTTPS requests for the WinRM transport is disabled. HTTPS WinRM
-connections are still encrypted, but knife is not able to detect forged replies
-or spoofing attacks.
-
-To fix this issue add an entry like this to your knife configuration file:
-
-```
-  # Verify all WinRM HTTPS connections (default, recommended)
-  knife[:winrm_ssl_verify_mode] = :verify_peer
-```
-* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
-WARN
+      def relay_winrm_command(command)
+        Chef::Log.debug(command)
+        @winrm_sessions.each do |s|
+          s.relay_command(command)
         end
       end
+
+      # TODO: Copied from Knife::Core:GenericPresenter. Should be extracted
+      def extract_nested_value(data, nested_value_spec)
+        nested_value_spec.split(".").each do |attr|
+          if data.nil?
+            nil # don't get no method error on nil
+          elsif data.respond_to?(attr.to_sym)
+            data = data.send(attr.to_sym)
+          elsif data.respond_to?(:[])
+            data = data[attr]
+          else
+            data = begin
+                     data.send(attr.to_sym)
+                   rescue NoMethodError
+                     nil
+                   end
+          end
+        end
+        ( !data.kind_of?(Array) && data.respond_to?(:to_hash) ) ? data.to_hash : data
+      end
+
+      private
+
+      def interactive
+        puts "WARN: Deprecated functionality. This will not be supported in future knife-windows releases."
+        puts "Connected to #{ui.list(session.servers.collect { |s| ui.color(s.host, :cyan) }, :inline, " and ")}"
+        puts
+        puts "To run a command on a list of servers, do:"
+        puts "  on SERVER1 SERVER2 SERVER3; COMMAND"
+        puts "  Example: on latte foamy; echo foobar"
+        puts
+        puts "To exit interactive mode, use 'quit!'"
+        puts
+        while 1
+          command = read_line
+          case command
+          when 'quit!'
+            puts 'Bye!'
+            break
+          when /^on (.+?); (.+)$/
+            raw_list = $1.split(" ")
+            server_list = Array.new
+            @winrm_sessions.each do |session_server|
+              server_list << session_server if raw_list.include?(session_server.host)
+            end
+            command = $2
+            relay_winrm_command(command, server_list)
+          else
+            relay_winrm_command(command)
+          end
+        end
+      end
+
+      def check_for_errors!
+        @winrm_sessions.each do |session|
+          session_exit_code = session.exit_code
+          unless success_return_codes.include? session_exit_code.to_i
+            @exit_code = session_exit_code.to_i
+            ui.error "Failed to execute command on #{session.host} return code #{session_exit_code}"
+          end
+        end
+      end
+
+      # Present the prompt and read a single line from the console. It also
+      # detects ^D and returns "exit" in that case. Adds the input to the
+      # history, unless the input is empty. Loops repeatedly until a non-empty
+      # line is input.
+      def read_line
+        loop do
+          command = reader.readline("#{ui.color('knife-winrm>', :bold)} ", true)
+
+          if command.nil?
+            command = "exit"
+            puts(command)
+          else
+            command.strip!
+          end
+
+          unless command.empty?
+            return command
+          end
+        end
+      end
+
+      def reader        
+        Readline
+      end
+
+      def success_return_codes
+        #Redundant if the CLI options parsing occurs
+        return [0] unless config[:returns]
+        return @success_return_codes ||= config[:returns].split(',').collect {|item| item.to_i}
+      end      
     end
   end
 end

--- a/lib/chef/knife/winrm_base.rb
+++ b/lib/chef/knife/winrm_base.rb
@@ -114,7 +114,9 @@ class Chef
 
       def locate_config_value(key)
         key = key.to_sym
-        config[key] || Chef::Config[:knife][key]
+        value = config[key] || Chef::Config[:knife][key] || default_config[key]
+        Chef::Log.debug("Looking for key #{key} and found value #{value}")
+        value
       end
     end
   end

--- a/lib/chef/knife/winrm_knife_base.rb
+++ b/lib/chef/knife/winrm_knife_base.rb
@@ -23,20 +23,20 @@ require 'chef/knife/winrm_shared_options'
 
 class Chef
   class Knife
-    module WinrmCommandSharedFunctions  
+    module WinrmCommandSharedFunctions
       def self.included(includer)
         includer.class_eval do
 
           @@ssl_warning_given = false
 
           include Chef::Knife::WinrmBase
-          include Chef::Knife::WinrmSharedOptions          
+          include Chef::Knife::WinrmSharedOptions
 
           #Overrides Chef::Knife#configure_session, as that code is tied to the SSH implementation
           #Tracked by Issue # 3042 / https://github.com/chef/chef/issues/3042
-          def configure_session               
+          def configure_session
             resolve_session_options
-            resolve_target_nodes       
+            resolve_target_nodes
             session_from_list
           end
 
@@ -76,7 +76,7 @@ class Chef
 
           def session_from_list
             @list.each do |item|
-              Chef::Log.debug("Adding #{item}")          
+              Chef::Log.debug("Adding #{item}")
               @session_opts[:host] = item
               create_winrm_session(@session_opts)
             end
@@ -86,21 +86,21 @@ class Chef
             session = Chef::Knife::WinrmSession.new(options)
             @winrm_sessions ||= []
             @winrm_sessions.push(session)
-          end 
+          end
 
           def resolve_session_options
             resolve_winrm_basic_options
             resolve_winrm_auth_settings
             resolve_winrm_kerberos_options
             resolve_winrm_transport_options
-            resolve_winrm_ssl_options            
+            resolve_winrm_ssl_options
           end
 
           def resolve_winrm_basic_options
             @session_opts = {}
             @session_opts[:user] = locate_config_value(:winrm_user)
             @session_opts[:password] = locate_config_value(:winrm_password)
-  
+
             # set default winrm_port = 5986 for ssl transport
             # set default winrm_port = 5985 for plaintext transport
             case locate_config_value(:winrm_transport)
@@ -108,10 +108,10 @@ class Chef
               Chef::Config[:knife][:winrm_port] = "5986"
             else
               Chef::Config[:knife][:winrm_port] = "5985"
-            end        
+            end
             @session_opts[:port] = locate_config_value(:winrm_port)
             #30 min (Default) OperationTimeout for long bootstraps fix for KNIFE_WINDOWS-8
-            @session_opts[:operation_timeout] = locate_config_value(:session_timeout).to_i * 60 if locate_config_value(:session_timeout)        
+            @session_opts[:operation_timeout] = locate_config_value(:session_timeout).to_i * 60 if locate_config_value(:session_timeout)
           end
 
           def resolve_winrm_kerberos_options
@@ -119,45 +119,45 @@ class Chef
               @session_opts[:transport] = :kerberos
               @session_opts[:keytab] = locate_config_value(:kerberos_keytab_file) if locate_config_value(:kerberos_keytab_file)
               @session_opts[:realm] = locate_config_value(:kerberos_realm) if locate_config_value(:kerberos_realm)
-              @session_opts[:service] = locate_config_value(:kerberos_service) if locate_config_value(:kerberos_service)        
+              @session_opts[:service] = locate_config_value(:kerberos_service) if locate_config_value(:kerberos_service)
             end
           end
 
           def resolve_winrm_transport_options
             @session_opts[:disable_sspi] = true
             @session_opts[:transport] = locate_config_value(:winrm_transport).to_sym unless @session_opts[:transport] == :kerberos
-            if negotiate_auth? && @session_opts[:transport] == :ssl                
+            if negotiate_auth? && @session_opts[:transport] == :ssl
                 Chef::Log.debug("Trying WinRM communication with negotiate authentication and :ssl transport")
             elsif use_windows_native_auth?
               load_windows_specific_gems
               @session_opts[:transport] = :sspinegotiate
-              @session_opts[:disable_sspi] = false              
+              @session_opts[:disable_sspi] = false
             elsif negotiate_auth? && !Chef::Platform.windows?
               ui.warn "The '--winrm-authentication-protocol = negotiate' with 'plaintext' transport is only supported when this tool is invoked from a Windows-based system."
               ui.info "Try '--winrm-authentication-protocol = basic'"
               exit 1
-            end        
+            end
           end
 
           def resolve_winrm_ssl_options
             @session_opts[:ca_trust_path] = locate_config_value(:ca_trust_file) if locate_config_value(:ca_trust_file)
             @session_opts[:no_ssl_peer_verification] = no_ssl_peer_verification?(@session_opts[:ca_trust_path])
-            warn_no_ssl_peer_verification if @session_opts[:no_ssl_peer_verification]        
+            warn_no_ssl_peer_verification if @session_opts[:no_ssl_peer_verification]
           end
 
           def resolve_winrm_auth_settings
             winrm_auth_protocol = locate_config_value(:winrm_authentication_protocol)
-            if ! Chef::Knife::WinrmBase::WINRM_AUTH_PROTOCOL_LIST.include?(winrm_auth_protocol)              
+            if ! Chef::Knife::WinrmBase::WINRM_AUTH_PROTOCOL_LIST.include?(winrm_auth_protocol)
               ui.error "Invalid value '#{winrm_auth_protocol}' for --winrm-authentication-protocol option."
               ui.info "Valid values are #{Chef::Knife::WinrmBase::WINRM_AUTH_PROTOCOL_LIST.join(",")}."
               exit 1
-            end  
+            end
 
             if winrm_auth_protocol == "basic"
               @session_opts[:basic_auth_only] = true
             else
               @session_opts[:basic_auth_only] = false
-            end           
+            end
           end
 
           def no_ssl_peer_verification?(ca_trust_path)
@@ -165,10 +165,10 @@ class Chef
           end
 
           def use_windows_native_auth?
-           Chef::Platform.windows? && @session_opts[:transport] != :ssl && negotiate_auth? 
+           Chef::Platform.windows? && @session_opts[:transport] != :ssl && negotiate_auth?
           end
 
-          def load_windows_specific_gems            
+          def load_windows_specific_gems
             require 'winrm-s'
             Chef::Log.debug("Applied 'winrm-s' monkey patch and trying WinRM communication with 'sspinegotiate'")
           end

--- a/lib/chef/knife/winrm_knife_base.rb
+++ b/lib/chef/knife/winrm_knife_base.rb
@@ -1,0 +1,209 @@
+#
+# Author:: Steven Murawski (<smurawski@chef.io)
+# Copyright:: Copyright (c) 2015 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+require 'chef/knife'
+require 'chef/knife/winrm_base'
+require 'chef/knife/winrm_shared_options'
+
+class Chef
+  class Knife
+    module WinrmCommandSharedFunctions  
+      def self.included(includer)
+        includer.class_eval do
+
+          @@ssl_warning_given = false
+
+          include Chef::Knife::WinrmBase
+          include Chef::Knife::WinrmSharedOptions          
+
+          #Overrides Chef::Knife#configure_session, as that code is tied to the SSH implementation
+          #Tracked by Issue # 3042 / https://github.com/chef/chef/issues/3042
+          def configure_session               
+            resolve_session_options
+            resolve_target_nodes       
+            session_from_list
+          end
+
+          def resolve_target_nodes
+            @list = case config[:manual]
+                   when true
+                     @name_args[0].split(" ")
+                   when false
+                     r = Array.new
+                     q = Chef::Search::Query.new
+                     @action_nodes = q.search(:node, @name_args[0])[0]
+                     @action_nodes.each do |item|
+                       i = extract_nested_value(item, config[:attribute])
+                       r.push(i) unless i.nil?
+                     end
+                     r
+                   end
+             if @list.length == 0
+              if @action_nodes.length == 0
+                ui.fatal("No nodes returned from search!")
+              else
+                ui.fatal("#{@action_nodes.length} #{@action_nodes.length > 1 ? "nodes":"node"} found, " +
+                         "but does not have the required attribute (#{config[:attribute]}) to establish the connection. " +
+                         "Try setting another attribute to open the connection using --attribute.")
+              end
+              exit 10
+            end
+          end
+
+          def validate_password
+            if @session_opts[:user] and (not @session_opts[:password])
+              @session_opts[:password] = Chef::Config[:knife][:winrm_password] = config[:winrm_password] = get_password
+            end
+          end
+
+          private
+
+          def session_from_list
+            @list.each do |item|
+              Chef::Log.debug("Adding #{item}")          
+              @session_opts[:host] = item
+              create_winrm_session(@session_opts)
+            end
+          end
+
+          def create_winrm_session(options={})
+            session = Chef::Knife::WinrmSession.new(options)
+            @winrm_sessions ||= []
+            @winrm_sessions.push(session)
+          end 
+
+          def resolve_session_options
+            resolve_winrm_basic_options
+            resolve_winrm_auth_settings
+            resolve_winrm_kerberos_options
+            resolve_winrm_transport_options
+            resolve_winrm_ssl_options            
+          end
+
+          def resolve_winrm_basic_options
+            @session_opts = {}
+            @session_opts[:user] = locate_config_value(:winrm_user)
+            @session_opts[:password] = locate_config_value(:winrm_password)
+  
+            # set default winrm_port = 5986 for ssl transport
+            # set default winrm_port = 5985 for plaintext transport
+            case locate_config_value(:winrm_transport)
+            when 'ssl'
+              Chef::Config[:knife][:winrm_port] = "5986"
+            else
+              Chef::Config[:knife][:winrm_port] = "5985"
+            end        
+            @session_opts[:port] = locate_config_value(:winrm_port)
+            #30 min (Default) OperationTimeout for long bootstraps fix for KNIFE_WINDOWS-8
+            @session_opts[:operation_timeout] = locate_config_value(:session_timeout).to_i * 60 if locate_config_value(:session_timeout)        
+          end
+
+          def resolve_winrm_kerberos_options
+            if config.keys.any? {|k| k.to_s =~ /kerberos/ }
+              @session_opts[:transport] = :kerberos
+              @session_opts[:keytab] = locate_config_value(:kerberos_keytab_file) if locate_config_value(:kerberos_keytab_file)
+              @session_opts[:realm] = locate_config_value(:kerberos_realm) if locate_config_value(:kerberos_realm)
+              @session_opts[:service] = locate_config_value(:kerberos_service) if locate_config_value(:kerberos_service)        
+            end
+          end
+
+          def resolve_winrm_transport_options
+            @session_opts[:disable_sspi] = true
+            @session_opts[:transport] = locate_config_value(:winrm_transport).to_sym unless @session_opts[:transport] == :kerberos
+            if negotiate_auth? && @session_opts[:transport] == :ssl                
+                Chef::Log.debug("Trying WinRM communication with negotiate authentication and :ssl transport")
+            elsif use_windows_native_auth?
+              load_windows_specific_gems
+              @session_opts[:transport] = :sspinegotiate
+              @session_opts[:disable_sspi] = false              
+            elsif negotiate_auth? && !Chef::Platform.windows?
+              ui.warn "The '--winrm-authentication-protocol = negotiate' with 'plaintext' transport is only supported when this tool is invoked from a Windows-based system."
+              ui.info "Try '--winrm-authentication-protocol = basic'"
+              exit 1
+            end        
+          end
+
+          def resolve_winrm_ssl_options
+            @session_opts[:ca_trust_path] = locate_config_value(:ca_trust_file) if locate_config_value(:ca_trust_file)
+            @session_opts[:no_ssl_peer_verification] = no_ssl_peer_verification?(@session_opts[:ca_trust_path])
+            warn_no_ssl_peer_verification if @session_opts[:no_ssl_peer_verification]        
+          end
+
+          def resolve_winrm_auth_settings
+            winrm_auth_protocol = locate_config_value(:winrm_authentication_protocol)
+            if ! Chef::Knife::WinrmBase::WINRM_AUTH_PROTOCOL_LIST.include?(winrm_auth_protocol)              
+              ui.error "Invalid value '#{winrm_auth_protocol}' for --winrm-authentication-protocol option."
+              ui.info "Valid values are #{Chef::Knife::WinrmBase::WINRM_AUTH_PROTOCOL_LIST.join(",")}."
+              exit 1
+            end  
+
+            if winrm_auth_protocol == "basic"
+              @session_opts[:basic_auth_only] = true
+            else
+              @session_opts[:basic_auth_only] = false
+            end           
+          end
+
+          def no_ssl_peer_verification?(ca_trust_path)
+            ca_trust_path.nil? && (config[:winrm_ssl_verify_mode] == :verify_none)
+          end
+
+          def use_windows_native_auth?
+           Chef::Platform.windows? && @session_opts[:transport] != :ssl && negotiate_auth? 
+          end
+
+          def load_windows_specific_gems            
+            require 'winrm-s'
+            Chef::Log.debug("Applied 'winrm-s' monkey patch and trying WinRM communication with 'sspinegotiate'")
+          end
+
+          def get_password
+            @password ||= ui.ask("Enter your password: ") { |q| q.echo = false }
+          end
+
+          # returns true if winrm_authentication_protocol is 'negotiate'
+          def negotiate_auth?
+            locate_config_value(:winrm_authentication_protocol) == "negotiate"
+          end
+
+          def warn_no_ssl_peer_verification
+            if ! @@ssl_warning_given
+              @@ssl_warning_given = true
+              ui.warn(<<-WARN)
+* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+SSL validation of HTTPS requests for the WinRM transport is disabled. HTTPS WinRM
+connections are still encrypted, but knife is not able to detect forged replies
+or spoofing attacks.
+
+To fix this issue add an entry like this to your knife configuration file:
+
+```
+  # Verify all WinRM HTTPS connections (default, recommended)
+  knife[:winrm_ssl_verify_mode] = :verify_peer
+```
+* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+WARN
+                end
+              end
+
+        end
+      end
+    end
+  end
+end

--- a/lib/chef/knife/winrm_session.rb
+++ b/lib/chef/knife/winrm_session.rb
@@ -1,0 +1,72 @@
+#
+# Author:: Steven Murawski <smurawski@chef.io>
+# Copyright:: Copyright (c) 2015 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'winrm'
+
+class Chef
+  class Knife
+    class WinrmSession
+        attr_reader :host, :endpoint, :port, :output, :error, :exit_code
+        def initialize(options)
+          @host = options[:host]
+          @port = options[:port]
+          url = "#{options[:host]}:#{options[:port]}/wsman"
+          scheme = options[:transport] == :ssl ? 'https' : 'http'
+          @endpoint = "#{scheme}://#{url}"
+          opts = Hash.new
+          opts = {:user => options[:user], :pass => options[:password], :basic_auth_only => options[:basic_auth_only], :disable_sspi => options[:disable_sspi], :no_ssl_peer_verification => options[:no_ssl_peer_verification]}
+
+          options[:transport] == :kerberos ? opts.merge!({:service => options[:service], :realm => options[:realm], :keytab => options[:keytab]}) : opts.merge!({:ca_trust_path => options[:ca_trust_path]})
+          
+          Chef::Log.debug("WinRM::WinRMWebService options: #{opts}")
+          Chef::Log.debug("Endpoint: #{endpoint}")
+          Chef::Log.debug("Transport: #{options[:transport]}")
+          @winrm_session = WinRM::WinRMWebService.new(@endpoint, options[:transport], opts)
+          @winrm_session.set_timeout(options[:operation_timeout]) if options[:operation_timeout]
+        end
+        
+        def relay_command(command)
+          remote_id = @winrm_session.open_shell
+          command_id = @winrm_session.run_command(remote_id, command)
+          Chef::Log.debug("#{@host}[#{remote_id}] => :run_command[#{command}]")
+          session_result = get_output(remote_id, command_id)
+          @winrm_session.cleanup_command(remote_id, command_id)
+          Chef::Log.debug("#{@host}[#{remote_id}] => :command_cleanup[#{command}]")
+          @exit_code = session_result[:exitcode]
+          @winrm_session.close_shell(remote_id)
+          Chef::Log.debug("#{@host}[#{remote_id}] => :shell_close")
+        end
+
+        def get_output(remote_id, command_id)
+          @winrm_session.get_command_output(remote_id, command_id) do |out,error|
+            print_data(@host, out) if out
+            print_data(@host, error, :red) if error
+          end
+        end
+
+        def print_data(host, data, color = :cyan)
+          if data =~ /\n/
+            data.split(/\n/).each { |d| print_data(host, d, color) }
+          elsif !data.nil?
+            print Chef::Knife::Winrm.ui.color(host, color)
+            puts " #{data}"
+          end
+        end
+    end
+  end
+end

--- a/lib/chef/knife/winrm_session.rb
+++ b/lib/chef/knife/winrm_session.rb
@@ -32,14 +32,14 @@ class Chef
           opts = {:user => options[:user], :pass => options[:password], :basic_auth_only => options[:basic_auth_only], :disable_sspi => options[:disable_sspi], :no_ssl_peer_verification => options[:no_ssl_peer_verification]}
 
           options[:transport] == :kerberos ? opts.merge!({:service => options[:service], :realm => options[:realm], :keytab => options[:keytab]}) : opts.merge!({:ca_trust_path => options[:ca_trust_path]})
-          
+
           Chef::Log.debug("WinRM::WinRMWebService options: #{opts}")
           Chef::Log.debug("Endpoint: #{endpoint}")
           Chef::Log.debug("Transport: #{options[:transport]}")
           @winrm_session = WinRM::WinRMWebService.new(@endpoint, options[:transport], opts)
           @winrm_session.set_timeout(options[:operation_timeout]) if options[:operation_timeout]
         end
-        
+
         def relay_command(command)
           remote_id = @winrm_session.open_shell
           command_id = @winrm_session.run_command(remote_id, command)

--- a/lib/chef/knife/winrm_shared_options.rb
+++ b/lib/chef/knife/winrm_shared_options.rb
@@ -1,0 +1,47 @@
+#
+# Author:: Steven Murawski (<smurawski@chef.io)
+# Copyright:: Copyright (c) 2015 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'chef/knife'
+require 'chef/encrypted_data_bag_item'
+require 'kconv'
+
+class Chef
+  class Knife
+    module WinrmSharedOptions
+
+      # Shared command line options for knife winrm and knife wsman test
+      def self.included(includer)
+        includer.class_eval do
+          option :manual,
+            :short => "-m",
+            :long => "--manual-list",
+            :boolean => true,
+            :description => "QUERY is a space separated list of servers",
+            :default => false
+
+          option :attribute,
+            :short => "-a ATTR",
+            :long => "--attribute ATTR",
+            :description => "The attribute to use for opening the connection - default is fqdn",
+            :default => "fqdn"
+        end
+      end
+
+    end
+  end
+end

--- a/lib/chef/knife/wsman_endpoint.rb
+++ b/lib/chef/knife/wsman_endpoint.rb
@@ -1,0 +1,44 @@
+#
+# Author:: Steven Murawski (<smurawski@chef.io)
+# Copyright:: Copyright (c) 2015 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+class Chef
+  class Knife
+    class WsmanEndpoint
+      attr_accessor :host
+      attr_accessor :wsman_port
+      attr_accessor :wsman_url
+      attr_accessor :product_version
+      attr_accessor :protocol_version
+      attr_accessor :product_vendor
+      attr_accessor :response_status_code
+      attr_accessor :error_message
+
+      def initialize(name, port, url)
+        @host = name
+        @wsman_port = port
+        @wsman_url = url
+      end
+
+      def to_hash
+        hash = {}
+        instance_variables.each {|var| hash[var.to_s.delete("@")] = instance_variable_get(var) }
+        hash
+      end
+    end
+  end
+end

--- a/lib/chef/knife/wsman_test.rb
+++ b/lib/chef/knife/wsman_test.rb
@@ -1,0 +1,77 @@
+#
+# Author:: Steven Murawski (<smurawski@chef.io>)
+# Copyright:: Copyright (c) 2015 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'httpclient'
+require 'nokogiri'
+require 'chef/knife'
+require 'chef/knife/winrm_knife_base'
+require 'chef/knife/wsman_endpoint'
+
+
+class Chef
+  class Knife
+    class WsmanTest < Knife
+
+      include Chef::Knife::WinrmCommandSharedFunctions 
+
+      deps do
+        require 'chef/search/query'
+      end
+
+      banner "knife wsman test QUERY (options)"
+
+      def run
+        @config[:winrm_authentication_protocol] = 'basic'
+        configure_session
+        verify_wsman_accessiblity_for_nodes        
+      end  
+
+      def verify_wsman_accessiblity_for_nodes           
+        @winrm_sessions.each do |item|
+          Chef::Log.debug("checking for WSMAN availability at #{item.endpoint}")
+
+          xml = '<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope" xmlns:wsmid="http://schemas.dmtf.org/wbem/wsman/identity/1/wsmanidentity.xsd"><s:Header/><s:Body><wsmid:Identify/></s:Body></s:Envelope>'
+          header = {
+            'WSMANIDENTIFY' => 'unauthenticated',
+            'Content-Type' => 'application/soap+xml; charset=UTF-8'
+          }
+          output_object = Chef::Knife::WsmanEndpoint.new(item.host, item.port, item.endpoint)      
+
+          begin
+            client = HTTPClient.new
+            response = client.post(item.endpoint, xml, header)
+          rescue Exception => e
+            output_object.error_message = e.message
+          else
+            output_object.response_status_code = response.status_code 
+          end
+
+          if not response.nil? and response.status_code == 200
+            doc = Nokogiri::XML response.body   
+            namespace = 'http://schemas.dmtf.org/wbem/wsman/identity/1/wsmanidentity.xsd'         
+            output_object.protocol_version = doc.xpath('//wsmid:ProtocolVersion', 'wsmid' => namespace).text
+            output_object.product_version  = doc.xpath('//wsmid:ProductVersion',  'wsmid' => namespace).text
+            output_object.product_vendor  = doc.xpath('//wsmid:ProductVendor',   'wsmid' => namespace).text                       
+          end
+
+          output(output_object)          
+        end        
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,6 +23,7 @@ end
 
 require_relative '../lib/chef/knife/core/windows_bootstrap_context'
 require_relative '../lib/chef/knife/bootstrap_windows_winrm'
+require_relative '../lib/chef/knife/wsman_test'
 
 if windows?
   require 'ruby-wmi'

--- a/spec/unit/knife/bootstrap_windows_winrm_spec.rb
+++ b/spec/unit/knife/bootstrap_windows_winrm_spec.rb
@@ -36,7 +36,7 @@ describe Chef::Knife::BootstrapWindowsWinrm do
   end
 
   let(:bootstrap) { Chef::Knife::BootstrapWindowsWinrm.new(['winrm', '-d', 'windows-chef-client-msi',  '-x', 'Administrator', 'localhost']) }
-  let(:session) { Chef::Knife::Winrm::Session.new(host: 'https://winrm.cloudapp.net:5986/wsman', transport: :ssl) }
+  let(:session) { Chef::Knife::Winrm::WinrmSession.new({ :host => 'winrm.cloudapp.net', :port => '5986', :transport => :ssl }) }
 
   let(:initial_fail_count) { 4 }
   it 'should retry if a 401 is received from WinRM' do
@@ -62,7 +62,7 @@ describe Chef::Knife::BootstrapWindowsWinrm do
   end
 
   it 'should have a wait timeout of 2 minutes by default' do
-    allow(bootstrap).to receive(:run_command).and_raise(WinRM::WinRMHTTPTransportError.new('', '500'))
+    allow(bootstrap).to receive(:run_command).and_raise(WinRM::WinRMHTTPTransportError.new('','500'))
     allow(bootstrap).to receive(:create_bootstrap_bat_command).and_raise(SystemExit)
     expect(bootstrap).to receive(:wait_for_remote_response).with(2)
     allow(bootstrap).to receive(:validate_name_args!).and_return(nil)
@@ -87,13 +87,8 @@ describe Chef::Knife::BootstrapWindowsWinrm do
 
     #Stub out calls to create the session and just get the exit codes back
     winrm_mock = Chef::Knife::Winrm.new
-    allow(Chef::Knife::Winrm).to receive(:new).and_return(winrm_mock)
-    allow(winrm_mock).to receive(:configure_session)
-    allow(winrm_mock).to receive(:relay_winrm_command)
-    allow(winrm_mock.ui).to receive(:error)
-    winrm_mock.instance_variable_set(:@winrm_sessions,[session])
-    allow(session).to receive(:exit_code).and_return(command_status)
-    allow(Chef::Knife::Winrm::Session).to receive(:new).and_return(session)
+    allow(Chef::Knife::Winrm).to receive(:new).and_return(winrm_mock)    
+    allow(winrm_mock).to receive(:run).and_raise(SystemExit.new(command_status))
     #Skip over templating stuff and checking with the remote end
     allow(bootstrap).to receive(:create_bootstrap_bat_command)
     allow(bootstrap).to receive(:wait_for_remote_response)

--- a/spec/unit/knife/winrm_session_spec.rb
+++ b/spec/unit/knife/winrm_session_spec.rb
@@ -1,0 +1,47 @@
+#
+# Author:: Steven Murawski <smurawski@chef.io>
+# Copyright:: Copyright (c) 2015 Opscode, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+
+Chef::Knife::Winrm.load_deps
+
+
+describe Chef::Knife::WinrmSession do
+  describe "#relay_command" do
+    before do
+      @service_mock = Object.new
+      @service_mock.define_singleton_method(:open_shell){}
+      @service_mock.define_singleton_method(:run_command){}
+      @service_mock.define_singleton_method(:cleanup_command){}
+      @service_mock.define_singleton_method(:get_command_output){|t,y| {}}
+      @service_mock.define_singleton_method(:close_shell){}
+      allow(Chef::Knife::WinrmSession).to receive(:new).with(hash_including(:transport => :plaintext)).and_call_original
+      allow(WinRM::WinRMWebService).to receive(:new).and_return(@service_mock)
+      @session = Chef::Knife::WinrmSession.new({transport: :plaintext})
+    end
+
+    it "run command and display commands output" do
+      expect(@service_mock).to receive(:open_shell).ordered
+      expect(@service_mock).to receive(:run_command).ordered
+      expect(@service_mock).to receive(:get_command_output).ordered.and_return({})
+      expect(@service_mock).to receive(:cleanup_command).ordered
+      expect(@service_mock).to receive(:close_shell).ordered
+      @session.relay_command("cmd.exe echo 'hi'")
+    end
+  end
+end

--- a/spec/unit/knife/winrm_spec.rb
+++ b/spec/unit/knife/winrm_spec.rb
@@ -51,7 +51,7 @@ describe Chef::Knife::Winrm do
     context "when there are some hosts found but they do not have an attribute to connect with" do
       before do
         @knife.config[:manual] = false
-        @knife.config[:winrm_password] = 'P@ssw0rd!'        
+        @knife.config[:winrm_password] = 'P@ssw0rd!'
         allow(@query).to receive(:search).and_return([[@node_foo, @node_bar]])
         @node_foo.automatic_attrs[:fqdn] = nil
         @node_bar.automatic_attrs[:fqdn] = nil
@@ -75,7 +75,7 @@ describe Chef::Knife::Winrm do
       end
 
       it "should use nested attributes (KNIFE-276)" do
-        @knife.config[:attribute] = "ec2.public_hostname"        
+        @knife.config[:attribute] = "ec2.public_hostname"
         @knife.configure_chef
         @knife.resolve_target_nodes
       end
@@ -85,7 +85,7 @@ describe Chef::Knife::Winrm do
       context "when configuring the WinRM transport" do
         before(:all) do
           @winrm_session = Object.new
-          @winrm_session.define_singleton_method(:set_timeout){|timeout| ""}          
+          @winrm_session.define_singleton_method(:set_timeout){|timeout| ""}
         end
         after(:each) do
           Chef::Config.configuration = @original_config
@@ -94,11 +94,11 @@ describe Chef::Knife::Winrm do
 
         context "on windows workstations" do
           let(:winrm_command_windows_http) { Chef::Knife::Winrm.new(['-m', 'localhost', '-x', 'testuser', '-P', 'testpassword',  'echo helloworld'])        }
-          it "should default to negotiate when on a Windows host" do          
+          it "should default to negotiate when on a Windows host" do
             allow(Chef::Platform).to receive(:windows?).and_return(true)
             expect(winrm_command_windows_http).to receive(:load_windows_specific_gems)
             expect(Chef::Knife::WinrmSession).to receive(:new).with(hash_including(:transport => :sspinegotiate)).and_call_original
-            expect(WinRM::WinRMWebService).to receive(:new).with('http://localhost:5985/wsman', anything, anything).and_return(@winrm_session)          
+            expect(WinRM::WinRMWebService).to receive(:new).with('http://localhost:5985/wsman', anything, anything).and_return(@winrm_session)
             winrm_command_windows_http.configure_chef
             winrm_command_windows_http.configure_session
           end
@@ -110,35 +110,35 @@ describe Chef::Knife::Winrm do
           end
 
           let(:winrm_command_http) { Chef::Knife::Winrm.new(['-m', 'localhost', '-x', 'testuser', '-P', 'testpassword', '-t', 'plaintext', '--winrm-authentication-protocol', 'basic', 'echo helloworld'])        }
-          it "should default to the http uri scheme" do            
-            expect(Chef::Knife::WinrmSession).to receive(:new).with(hash_including(:transport => :plaintext)).and_call_original
-            expect(WinRM::WinRMWebService).to receive(:new).with('http://localhost:5985/wsman', anything, anything).and_return(@winrm_session)          
-            winrm_command_http.configure_chef
-            winrm_command_http.configure_session
-          end        
-          
-          it "set operation timeout and verify default" do                      
+          it "should default to the http uri scheme" do
             expect(Chef::Knife::WinrmSession).to receive(:new).with(hash_including(:transport => :plaintext)).and_call_original
             expect(WinRM::WinRMWebService).to receive(:new).with('http://localhost:5985/wsman', anything, anything).and_return(@winrm_session)
-            expect(@winrm_session).to receive(:set_timeout).with(1800)          
+            winrm_command_http.configure_chef
+            winrm_command_http.configure_session
+          end
+
+          it "set operation timeout and verify default" do
+            expect(Chef::Knife::WinrmSession).to receive(:new).with(hash_including(:transport => :plaintext)).and_call_original
+            expect(WinRM::WinRMWebService).to receive(:new).with('http://localhost:5985/wsman', anything, anything).and_return(@winrm_session)
+            expect(@winrm_session).to receive(:set_timeout).with(1800)
             winrm_command_http.configure_chef
             winrm_command_http.configure_session
           end
 
           it "should set user specified winrm port" do
-            Chef::Config[:knife] = {winrm_port: "5988"}            
+            Chef::Config[:knife] = {winrm_port: "5988"}
             expect(Chef::Knife::WinrmSession).to receive(:new).with(hash_including(:transport => :plaintext)).and_call_original
-            expect(WinRM::WinRMWebService).to receive(:new).with('http://localhost:5988/wsman', anything, anything).and_return(@winrm_session)          
+            expect(WinRM::WinRMWebService).to receive(:new).with('http://localhost:5988/wsman', anything, anything).and_return(@winrm_session)
             winrm_command_http.configure_chef
             winrm_command_http.configure_session
           end
-          
+
           let(:winrm_command_timeout) { Chef::Knife::Winrm.new(['-m', 'localhost', '-x', 'testuser', '-P', 'testpassword', '--winrm-authentication-protocol', 'basic', '--session-timeout', '10', 'echo helloworld'])        }
-           
-          it "set operation timeout and verify 10 Minute timeout" do                      
+
+          it "set operation timeout and verify 10 Minute timeout" do
             expect(Chef::Knife::WinrmSession).to receive(:new).with(hash_including(:transport => :plaintext)).and_call_original
             expect(WinRM::WinRMWebService).to receive(:new).with('http://localhost:5985/wsman', anything, anything).and_return(@winrm_session)
-            expect(@winrm_session).to receive(:set_timeout).with(600)          
+            expect(@winrm_session).to receive(:set_timeout).with(600)
             winrm_command_timeout.configure_chef
             winrm_command_timeout.configure_session
           end
@@ -146,22 +146,22 @@ describe Chef::Knife::Winrm do
           let(:winrm_command_https) { Chef::Knife::Winrm.new(['-m', 'localhost', '-x', 'testuser', '-P', 'testpassword', '--winrm-transport', 'ssl', 'echo helloworld'])       }
 
           it "should use the https uri scheme if the ssl transport is specified" do
-            Chef::Config[:knife] = {:winrm_transport => 'ssl'}            
+            Chef::Config[:knife] = {:winrm_transport => 'ssl'}
             expect(Chef::Knife::WinrmSession).to receive(:new).with(hash_including(:transport => :ssl)).and_call_original
-            expect(WinRM::WinRMWebService).to receive(:new).with('https://localhost:5986/wsman', anything, anything).and_return(@winrm_session)          
+            expect(WinRM::WinRMWebService).to receive(:new).with('https://localhost:5986/wsman', anything, anything).and_return(@winrm_session)
             winrm_command_https.configure_chef
             winrm_command_https.configure_session
           end
 
           it "should use the winrm port '5986' by default for ssl transport" do
-            Chef::Config[:knife] = {:winrm_transport => 'ssl'}            
+            Chef::Config[:knife] = {:winrm_transport => 'ssl'}
             expect(Chef::Knife::WinrmSession).to receive(:new).with(hash_including(:transport => :ssl)).and_call_original
-            expect(WinRM::WinRMWebService).to receive(:new).with('https://localhost:5986/wsman', anything, anything).and_return(@winrm_session)          
+            expect(WinRM::WinRMWebService).to receive(:new).with('https://localhost:5986/wsman', anything, anything).and_return(@winrm_session)
             winrm_command_https.configure_chef
             winrm_command_https.configure_session
           end
 
-          it "should default to validating the server when the ssl transport is used" do            
+          it "should default to validating the server when the ssl transport is used" do
             expect(Chef::Knife::WinrmSession).to receive(:new).with(hash_including(:transport => :ssl)).and_call_original
             expect(WinRM::WinRMWebService).to receive(:new).with(anything, anything, hash_including(:no_ssl_peer_verification => false)).and_return(@winrm_session)
             winrm_command_https.configure_chef
@@ -169,7 +169,7 @@ describe Chef::Knife::Winrm do
           end
 
           let(:winrm_command_verify_peer) { Chef::Knife::Winrm.new(['-m', 'localhost', '-x', 'testuser', '-P', 'testpassword', '--winrm-transport', 'ssl', '--winrm-ssl-verify-mode', 'verify_peer', 'echo helloworld'])}
-          it "should validate the server when the ssl transport is used and the :winrm_ssl_verify_mode option is not configured to :verify_none" do            
+          it "should validate the server when the ssl transport is used and the :winrm_ssl_verify_mode option is not configured to :verify_none" do
             expect(Chef::Knife::WinrmSession).to receive(:new).with(hash_including(:transport => :ssl)).and_call_original
             expect(WinRM::WinRMWebService).to receive(:new).with(anything, anything, hash_including(:no_ssl_peer_verification => false)).and_return(@winrm_session)
             winrm_command_verify_peer.configure_chef
@@ -178,14 +178,14 @@ describe Chef::Knife::Winrm do
 
           let(:winrm_command_no_verify) { Chef::Knife::Winrm.new(['-m', 'localhost', '-x', 'testuser', '-P', 'testpassword', '--winrm-transport', 'ssl', '--winrm-ssl-verify-mode', 'verify_none', 'echo helloworld'])}
 
-          it "should not validate the server when the ssl transport is used and the :winrm_ssl_verify_mode option is set to :verify_none" do            
+          it "should not validate the server when the ssl transport is used and the :winrm_ssl_verify_mode option is set to :verify_none" do
             expect(Chef::Knife::WinrmSession).to receive(:new).with(hash_including(:transport => :ssl)).and_call_original
             expect(WinRM::WinRMWebService).to receive(:new).with(anything, anything, hash_including(:no_ssl_peer_verification => true)).and_return(@winrm_session)
             winrm_command_no_verify.configure_chef
             winrm_command_no_verify.configure_session
           end
 
-          it "should provide warning output when the :winrm_ssl_verify_mode set to :verify_none to disable server validation" do            
+          it "should provide warning output when the :winrm_ssl_verify_mode set to :verify_none to disable server validation" do
             expect(Chef::Knife::WinrmSession).to receive(:new).with(hash_including(:transport => :ssl)).and_call_original
             expect(WinRM::WinRMWebService).to receive(:new).with(anything, anything, hash_including(:no_ssl_peer_verification => true)).and_return(@winrm_session)
             expect(winrm_command_no_verify).to receive(:warn_no_ssl_peer_verification)
@@ -196,7 +196,7 @@ describe Chef::Knife::Winrm do
 
           let(:winrm_command_ca_trust) { Chef::Knife::Winrm.new(['-m', 'localhost', '-x', 'testuser', '-P', 'testpassword', '--winrm-transport', 'ssl', '--ca-trust-file', '~/catrustroot', '--winrm-ssl-verify-mode', 'verify_none', 'echo helloworld'])}
 
-          it "should validate the server when the ssl transport is used and the :ca_trust_file option is specified even if the :winrm_ssl_verify_mode option is set to :verify_none" do            
+          it "should validate the server when the ssl transport is used and the :ca_trust_file option is specified even if the :winrm_ssl_verify_mode option is set to :verify_none" do
             expect(Chef::Knife::WinrmSession).to receive(:new).with(hash_including(:transport => :ssl)).and_call_original
             expect(WinRM::WinRMWebService).to receive(:new).with(anything, anything, hash_including(:no_ssl_peer_verification => false)).and_return(@winrm_session)
             winrm_command_ca_trust.configure_chef
@@ -231,7 +231,7 @@ describe Chef::Knife::Winrm do
           Chef::Config[:knife][:returns] = [0]
 
           allow(@winrm).to receive(:relay_winrm_command)
-          allow(@winrm.ui).to receive(:error)                    
+          allow(@winrm.ui).to receive(:error)
           allow(Chef::Knife::WinrmSession).to receive(:new).and_return(session_mock)
           allow(session_mock).to receive(:exit_code).and_return(command_status)
           expect { @winrm.run_with_pretty_exceptions }.to raise_error(SystemExit) { |e| expect(e.status).to eq(command_status) }
@@ -251,7 +251,7 @@ describe Chef::Knife::Winrm do
 
         it "should exit the process with a zero status if the command returns an expected non-zero status" do
           command_status = 53
-          Chef::Config[:knife][:returns] = [0,53]          
+          Chef::Config[:knife][:returns] = [0,53]
           allow(@winrm).to receive(:relay_winrm_command).and_return(command_status)
           session_mock = Chef::Knife::WinrmSession.new({:transport => :plaintext, :host => 'localhost', :port => '5985'})
           allow(Chef::Knife::WinrmSession).to receive(:new).and_return(session_mock)
@@ -262,7 +262,7 @@ describe Chef::Knife::Winrm do
 
         it "should exit the process with a zero status if the command returns an expected non-zero status" do
           command_status = 53
-          @winrm.config[:returns] = '0,53'          
+          @winrm.config[:returns] = '0,53'
           allow(@winrm).to receive(:relay_winrm_command).and_return(command_status)
           session_mock = Chef::Knife::WinrmSession.new({:transport => :plaintext, :host => 'localhost', :port => '5985'})
           allow(Chef::Knife::WinrmSession).to receive(:new).and_return(session_mock)
@@ -273,19 +273,19 @@ describe Chef::Knife::Winrm do
 
         it "should exit the process with 100 if command execution raises an exception other than 401" do
           allow(@winrm).to receive(:relay_winrm_command).and_raise(WinRM::WinRMHTTPTransportError.new('', '500'))
-          allow(@winrm.ui).to receive(:error)          
+          allow(@winrm.ui).to receive(:error)
           expect { @winrm.run_with_pretty_exceptions }.to raise_error(SystemExit) { |e| expect(e.status).to eq(100) }
         end
 
         it "should exit the process with 100 if command execution raises a 401" do
           allow(@winrm).to receive(:relay_winrm_command).and_raise(WinRM::WinRMHTTPTransportError.new('', '401'))
           allow(@winrm.ui).to receive(:info)
-          allow(@winrm.ui).to receive(:error)          
+          allow(@winrm.ui).to receive(:error)
           expect { @winrm.run_with_pretty_exceptions }.to raise_error(SystemExit) { |e| expect(e.status).to eq(100) }
         end
 
         it "should exit the process with 0 if command execution raises a 401 and suppress_auth_failure is set to true" do
-          @winrm.config[:suppress_auth_failure] = true          
+          @winrm.config[:suppress_auth_failure] = true
           allow(@winrm).to receive(:relay_winrm_command).and_raise(WinRM::WinRMHTTPTransportError.new('', '401'))
           exit_code = @winrm.run_with_pretty_exceptions
           expect(exit_code).to eq(401)
@@ -319,7 +319,7 @@ describe Chef::Knife::Winrm do
             @winrm.config[:winrm_user] = "domain\\testuser"
             allow(Chef::Platform).to receive(:windows?).and_return(true)
             allow(@winrm.ui).to receive(:warn)
-            expect(@winrm).to receive(:require).with('winrm-s').and_call_original          
+            expect(@winrm).to receive(:require).with('winrm-s').and_call_original
             exit_code = @winrm.run
           end
 

--- a/spec/unit/knife/wsman_test_spec.rb
+++ b/spec/unit/knife/wsman_test_spec.rb
@@ -23,86 +23,154 @@ describe Chef::Knife::WsmanTest do
     Chef::Config.reset
   end
 
-  context 'when testing the WSMAN endpoint' do
-    let(:wsman_tester) {Chef::Knife::WsmanTest.new(['-m', 'localhost'])}
-    context 'and the service does not respond' do 
-      error_message = 'A connection attempt failed because the connected party did not properly respond after a period of time.'      
 
-      it 'returns an object with an error message' do
-        http_client_mock = HTTPClient.new
+  context 'when testing the WSMAN endpoint' do
+    let(:wsman_tester) { Chef::Knife::WsmanTest.new(['-m', 'localhost']) }
+    let(:http_client_mock) {HTTPClient.new}
+
+    before(:each) do
+      wsman_tester.config[:verbosity] = 0
+      allow(HTTPClient).to receive(:new).and_return(http_client_mock)
+    end
+
+    context 'and the service does not respond' do
+      error_message = 'A connection attempt failed because the connected party did not properly respond after a period of time.'
+
+      before(:each) do
         allow(HTTPClient).to receive(:new).and_return(http_client_mock)
         allow(http_client_mock).to receive(:post).and_raise(Exception.new(error_message))
-        expect(wsman_tester).to receive(:output).with(duck_type(:error_message)) 
-        wsman_tester.run       
+      end
+
+      it 'exits with a status code of 1' do
+        expect(wsman_tester).to receive(:exit).with(1)
+        wsman_tester.run
+      end
+
+      it 'writes a warning message for each node it fails to connect to' do
+        expect(wsman_tester.ui).to receive(:warn)
+        expect(wsman_tester).to receive(:exit).with(1)
+        wsman_tester.run
+      end
+
+      it 'writes an error message if it fails to connect to any nodes' do
+        expect(wsman_tester.ui).to receive(:error)
+        expect(wsman_tester).to receive(:exit).with(1)
+        wsman_tester.run
       end
     end
 
-    context 'and the target node is Windows Server 2008 R2' do
-      response_body = <<-RESPONSEXML
-      <s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope"><s:Header/><s:Body><wsmid:IdentifyResponse xmlns:wsmid="http://schemas.dmtf.org/wbem/wsman/identity/1/wsmanidentity.xsd"><wsmid:ProtocolVersion>http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd</wsmid:ProtocolVersion><wsmid:ProductVendor>Microsoft Corporation</wsmid:ProductVendor><wsmid:ProductVersion>OS: 0.0.0 SP: 0.0 Stack: 2.0</wsmid:ProductVersion></wsmid:IdentifyResponse></s:Body></s:Envelope>
-      RESPONSEXML
-      before(:each) do
-        http_client_mock = HTTPClient.new
-        http_response_mock = HTTP::Message.new_response(response_body)                
-        allow(HTTPClient).to receive(:new).and_return(http_client_mock)
-        allow(http_client_mock).to receive(:post).and_return(http_response_mock)
-      end
-
-      it 'identifies the stack of the product version as 2.0 ' do        
-        expect(wsman_tester).to receive(:output) do |output|
-          expect(output.product_version).to  eq 'OS: 0.0.0 SP: 0.0 Stack: 2.0'
+    context 'and the service responds' do
+      context 'successfully' do
+        it 'writes a message about a successful connection' do
+          response_body = '<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope"><s:Header/><s:Body><wsmid:IdentifyResponse xmlns:wsmid="http://schemas.dmtf.org/wbem/wsman/identity/1/wsmanidentity.xsd"><wsmid:ProtocolVersion>http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd</wsmid:ProtocolVersion><wsmid:ProductVendor>Microsoft Corporation</wsmid:ProductVendor><wsmid:ProductVersion>OS: 0.0.0 SP: 0.0 Stack: 2.0</wsmid:ProductVersion></wsmid:IdentifyResponse></s:Body></s:Envelope>'
+          http_response_mock = HTTP::Message.new_response(response_body)
+          allow(http_client_mock).to receive(:post).and_return(http_response_mock)
+          expect(wsman_tester.ui).to receive(:msg)
+          wsman_tester.run
         end
-        wsman_tester.run   
       end
 
-      it 'identifies the protocol version as the current DMTF standard' do
-        expect(wsman_tester).to receive(:output) do |output|
-          expect(output.protocol_version).to  eq 'http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd'
+      context 'with an invalid body' do
+        it 'warns for a failed connection and exit with a status of 1' do
+          response_body = 'I am invalid'
+          http_response_mock = HTTP::Message.new_response(response_body)
+          allow(http_client_mock).to receive(:post).and_return(http_response_mock)
+          expect(wsman_tester.ui).to receive(:warn)
+          expect(wsman_tester.ui).to receive(:error)
+          expect(wsman_tester).to receive(:exit).with(1)
+          wsman_tester.run
         end
-        wsman_tester.run 
       end
 
-      it 'identifies the vendor as the Microsoft Corporation' do
-        expect(wsman_tester).to receive(:output) do |output|
-          expect(output.product_vendor).to  eq 'Microsoft Corporation'
+      context 'with a non-200 code' do
+        it 'warns for a failed connection and exits with a status of 1' do
+          http_response_mock = HTTP::Message.new_response('')
+          http_response_mock.status = 404
+          allow(http_client_mock).to receive(:post).and_return(http_response_mock)
+          expect(wsman_tester.ui).to receive(:warn)
+          expect(wsman_tester.ui).to receive(:error)
+          expect(wsman_tester).to receive(:exit).with(1)
+          wsman_tester.run
         end
-        wsman_tester.run  
-      end
-    end
-
-    context 'and the target node is Windows Server 2012 R2' do
-      response_body = <<-RESPONSEXML
-      <s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope"><s:Header/><s:Body><wsmid:IdentifyResponse xmlns:wsmid="http://schemas.dmtf.org/wbem/wsman/identity/1/wsmanidentity.xsd"><wsmid:ProtocolVersion>http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd</wsmid:ProtocolVersion><wsmid:ProductVendor>Microsoft Corporation</wsmid:ProductVendor><wsmid:ProductVersion>OS: 0.0.0 SP: 0.0 Stack: 3.0</wsmid:ProductVersion></wsmid:IdentifyResponse></s:Body></s:Envelope>
-      RESPONSEXML
-      before(:each) do
-        http_client_mock = HTTPClient.new
-        http_response_mock = HTTP::Message.new_response(response_body)                
-        allow(HTTPClient).to receive(:new).and_return(http_client_mock)
-        allow(http_client_mock).to receive(:post).and_return(http_response_mock)
-      end
-
-      it 'identifies the stack of the product version as 3.0 ' do        
-        expect(wsman_tester).to receive(:output) do |output|
-          expect(output.product_version).to  eq 'OS: 0.0.0 SP: 0.0 Stack: 3.0'
-        end
-        wsman_tester.run   
-      end
-
-      it 'identifies the protocol version as the current DMTF standard' do
-        expect(wsman_tester).to receive(:output) do |output|
-          expect(output.protocol_version).to  eq 'http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd'
-        end
-        wsman_tester.run 
-      end
-
-      it 'identifies the vendor as the Microsoft Corporation' do
-        expect(wsman_tester).to receive(:output) do |output|
-          expect(output.product_vendor).to  eq 'Microsoft Corporation'
-        end
-        wsman_tester.run  
       end
     end
   end
 
+  context 'when testing the WSMAN endpoint with verbose output' do
+    let(:wsman_tester_verbose) { Chef::Knife::WsmanTest.new(['-m', 'localhost']) }
+    let(:http_client_mock_verbose) {HTTPClient.new}
 
+    before(:each) do
+      allow(HTTPClient).to receive(:new).and_return(http_client_mock_verbose)
+      wsman_tester_verbose.config[:verbosity] = 1
+    end
+
+    context 'and the service does not respond' do
+      it 'returns an object with an error message' do
+        error_message = 'A connection attempt failed because the connected party did not properly respond after a period of time.'
+        allow(http_client_mock_verbose).to receive(:post).and_raise(Exception.new(error_message))
+        expect(wsman_tester_verbose).to receive(:output).with(duck_type(:error_message))
+        expect(wsman_tester_verbose).to receive(:exit).with(1)
+        wsman_tester_verbose.run
+      end
+    end
+
+    context 'and the target node is Windows Server 2008 R2' do
+      before(:each) do
+        ws2008r2_response_body = '<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope"><s:Header/><s:Body><wsmid:IdentifyResponse xmlns:wsmid="http://schemas.dmtf.org/wbem/wsman/identity/1/wsmanidentity.xsd"><wsmid:ProtocolVersion>http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd</wsmid:ProtocolVersion><wsmid:ProductVendor>Microsoft Corporation</wsmid:ProductVendor><wsmid:ProductVersion>OS: 0.0.0 SP: 0.0 Stack: 2.0</wsmid:ProductVersion></wsmid:IdentifyResponse></s:Body></s:Envelope>'
+        http_response_mock = HTTP::Message.new_response(ws2008r2_response_body)
+        allow(http_client_mock_verbose).to receive(:post).and_return(http_response_mock)
+      end
+
+      it 'identifies the stack of the product version as 2.0 ' do
+        expect(wsman_tester_verbose).to receive(:output) do |output|
+          expect(output.product_version).to  eq 'OS: 0.0.0 SP: 0.0 Stack: 2.0'
+        end
+        wsman_tester_verbose.run
+      end
+
+      it 'identifies the protocol version as the current DMTF standard' do
+        expect(wsman_tester_verbose).to receive(:output) do |output|
+          expect(output.protocol_version).to  eq 'http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd'
+        end
+        wsman_tester_verbose.run
+      end
+
+      it 'identifies the vendor as the Microsoft Corporation' do
+        expect(wsman_tester_verbose).to receive(:output) do |output|
+          expect(output.product_vendor).to  eq 'Microsoft Corporation'
+        end
+        wsman_tester_verbose.run
+      end
+    end
+
+    context 'and the target node is Windows Server 2012 R2' do
+      before(:each) do
+        ws2012_response_body = '<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope"><s:Header/><s:Body><wsmid:IdentifyResponse xmlns:wsmid="http://schemas.dmtf.org/wbem/wsman/identity/1/wsmanidentity.xsd"><wsmid:ProtocolVersion>http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd</wsmid:ProtocolVersion><wsmid:ProductVendor>Microsoft Corporation</wsmid:ProductVendor><wsmid:ProductVersion>OS: 0.0.0 SP: 0.0 Stack: 3.0</wsmid:ProductVersion></wsmid:IdentifyResponse></s:Body></s:Envelope>'
+        http_response_mock = HTTP::Message.new_response(ws2012_response_body)
+        allow(http_client_mock_verbose).to receive(:post).and_return(http_response_mock)
+      end
+
+      it 'identifies the stack of the product version as 3.0 ' do
+        expect(wsman_tester_verbose).to receive(:output) do |output|
+          expect(output.product_version).to  eq 'OS: 0.0.0 SP: 0.0 Stack: 3.0'
+        end
+        wsman_tester_verbose.run
+      end
+
+      it 'identifies the protocol version as the current DMTF standard' do
+        expect(wsman_tester_verbose).to receive(:output) do |output|
+          expect(output.protocol_version).to  eq 'http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd'
+        end
+        wsman_tester_verbose.run
+      end
+
+      it 'identifies the vendor as the Microsoft Corporation' do
+        expect(wsman_tester_verbose).to receive(:output) do |output|
+          expect(output.product_vendor).to  eq 'Microsoft Corporation'
+        end
+        wsman_tester_verbose.run
+      end
+    end
+  end
 end

--- a/spec/unit/knife/wsman_test_spec.rb
+++ b/spec/unit/knife/wsman_test_spec.rb
@@ -1,0 +1,108 @@
+#
+# Author:: Steven Murawski (<smurawski@chef.io>)
+# Copyright:: Copyright (c) 2015 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+
+describe Chef::Knife::WsmanTest do
+  before(:all) do
+    Chef::Config.reset
+  end
+
+  context 'when testing the WSMAN endpoint' do
+    let(:wsman_tester) {Chef::Knife::WsmanTest.new(['-m', 'localhost'])}
+    context 'and the service does not respond' do 
+      error_message = 'A connection attempt failed because the connected party did not properly respond after a period of time.'      
+
+      it 'returns an object with an error message' do
+        http_client_mock = HTTPClient.new
+        allow(HTTPClient).to receive(:new).and_return(http_client_mock)
+        allow(http_client_mock).to receive(:post).and_raise(Exception.new(error_message))
+        expect(wsman_tester).to receive(:output).with(duck_type(:error_message)) 
+        wsman_tester.run       
+      end
+    end
+
+    context 'and the target node is Windows Server 2008 R2' do
+      response_body = <<-RESPONSEXML
+      <s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope"><s:Header/><s:Body><wsmid:IdentifyResponse xmlns:wsmid="http://schemas.dmtf.org/wbem/wsman/identity/1/wsmanidentity.xsd"><wsmid:ProtocolVersion>http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd</wsmid:ProtocolVersion><wsmid:ProductVendor>Microsoft Corporation</wsmid:ProductVendor><wsmid:ProductVersion>OS: 0.0.0 SP: 0.0 Stack: 2.0</wsmid:ProductVersion></wsmid:IdentifyResponse></s:Body></s:Envelope>
+      RESPONSEXML
+      before(:each) do
+        http_client_mock = HTTPClient.new
+        http_response_mock = HTTP::Message.new_response(response_body)                
+        allow(HTTPClient).to receive(:new).and_return(http_client_mock)
+        allow(http_client_mock).to receive(:post).and_return(http_response_mock)
+      end
+
+      it 'identifies the stack of the product version as 2.0 ' do        
+        expect(wsman_tester).to receive(:output) do |output|
+          expect(output.product_version).to  eq 'OS: 0.0.0 SP: 0.0 Stack: 2.0'
+        end
+        wsman_tester.run   
+      end
+
+      it 'identifies the protocol version as the current DMTF standard' do
+        expect(wsman_tester).to receive(:output) do |output|
+          expect(output.protocol_version).to  eq 'http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd'
+        end
+        wsman_tester.run 
+      end
+
+      it 'identifies the vendor as the Microsoft Corporation' do
+        expect(wsman_tester).to receive(:output) do |output|
+          expect(output.product_vendor).to  eq 'Microsoft Corporation'
+        end
+        wsman_tester.run  
+      end
+    end
+
+    context 'and the target node is Windows Server 2012 R2' do
+      response_body = <<-RESPONSEXML
+      <s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope"><s:Header/><s:Body><wsmid:IdentifyResponse xmlns:wsmid="http://schemas.dmtf.org/wbem/wsman/identity/1/wsmanidentity.xsd"><wsmid:ProtocolVersion>http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd</wsmid:ProtocolVersion><wsmid:ProductVendor>Microsoft Corporation</wsmid:ProductVendor><wsmid:ProductVersion>OS: 0.0.0 SP: 0.0 Stack: 3.0</wsmid:ProductVersion></wsmid:IdentifyResponse></s:Body></s:Envelope>
+      RESPONSEXML
+      before(:each) do
+        http_client_mock = HTTPClient.new
+        http_response_mock = HTTP::Message.new_response(response_body)                
+        allow(HTTPClient).to receive(:new).and_return(http_client_mock)
+        allow(http_client_mock).to receive(:post).and_return(http_response_mock)
+      end
+
+      it 'identifies the stack of the product version as 3.0 ' do        
+        expect(wsman_tester).to receive(:output) do |output|
+          expect(output.product_version).to  eq 'OS: 0.0.0 SP: 0.0 Stack: 3.0'
+        end
+        wsman_tester.run   
+      end
+
+      it 'identifies the protocol version as the current DMTF standard' do
+        expect(wsman_tester).to receive(:output) do |output|
+          expect(output.protocol_version).to  eq 'http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd'
+        end
+        wsman_tester.run 
+      end
+
+      it 'identifies the vendor as the Microsoft Corporation' do
+        expect(wsman_tester).to receive(:output) do |output|
+          expect(output.product_vendor).to  eq 'Microsoft Corporation'
+        end
+        wsman_tester.run  
+      end
+    end
+  end
+
+
+end


### PR DESCRIPTION
This adds a command "knife wsman test" to help verify connectivity to remote WinRM endpoints.  Currently this can be tested from Windows nodes with PowerShell, but it is more difficult to validate connectivity cross platform.  This command will validate that the remote port is reachable and listening for management requests similar to Test-Wsman in PowerShell. 

Targets can be specified manually (as per the knife winrm command) or use search to identify target nodes.