### PR TITLE
vendored in cleanpath as well

### DIFF
--- a/lib/chef/knife/core/windows_bootstrap_context.rb
+++ b/lib/chef/knife/core/windows_bootstrap_context.rb
@@ -18,7 +18,6 @@
 
 require 'chef/knife/core/bootstrap_context'
 require 'chef/util/path_helper'
-require 'pry'
 
 class Chef
   class Knife


### PR DESCRIPTION
it looks like PathHelper is resolving from /opt/chefdk/embedded/apps/chef/lib/chef/util/path_helper.rb rather than the chef 12 client that is embedded.
