### PR TITLE
fixed ffi-yajl warning issue

### DIFF
--- a/knife-windows.gemspec
+++ b/knife-windows.gemspec
@@ -15,10 +15,10 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version	= ">= 1.9.1"
   s.add_dependency "winrm-s", "~> 0.2"
+  s.add_dependency "ffi-yajl", "< 1.3", "~> 1.2"
 
   s.add_development_dependency 'pry'
   s.add_development_dependency 'chef', '< 12'
-  s.add_dependency "ffi-yajl", "< 1.3", "~> 1.2"
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")


### PR DESCRIPTION
Getting this warning with `ffi-yajl -v1.3.1 gem`:

```
failed to load the ffi-yajl c-extension, falling back to ffi interface
ffi-yajl/json_gem is deprecated, these monkeypatches will be dropped shortly
```
