### PR TITLE
Changed .der extension to .b64

### DIFF
--- a/lib/chef/knife/windows_cert_generate.rb
+++ b/lib/chef/knife/windows_cert_generate.rb
@@ -118,9 +118,9 @@ class Chef
           cert = generate_certificate rsa_key
           write_certificate_to_file cert, file_path, rsa_key
           ui.info "Generated Certificates:"
-          ui.info " PKCS12 FORMAT (needed on the server machine, contains private key): #{file_path}.pfx"
-          ui.info " BASE64 ENCODED (used for creating SSL listener through cloud provider api, contains private key): #{file_path}.b64"
-          ui.info " PEM FORMAT (required by the client to connect to the server): #{file_path}.pem"
+          ui.info "- #{file_path}.pfx - PKCS12 format keypair. Contains both the public and private keys, usually used on the server."
+          ui.info "- #{file_path}.b64 - Base64 encoded PKCS12 keypair. Contains both the public and private keys, for upload to the Cloud REST API. e.g. Azure"
+          ui.info "- #{file_path}.pem - Base64 encoded public certificate only. Required by the client to connect to the server."
           ui.info "Certificate Thumbprint: #{@thumbprint.to_s.upcase}"
         rescue => e
           puts "ERROR: + #{e}"

--- a/lib/chef/knife/windows_cert_generate.rb
+++ b/lib/chef/knife/windows_cert_generate.rb
@@ -105,7 +105,7 @@ class Chef
         config[:cert_passphrase] = prompt_for_passphrase unless config[:cert_passphrase]
         pfx = OpenSSL::PKCS12.create("#{config[:cert_passphrase]}", "winrmcert", rsa_key, cert)
         File.open(file_path + ".pfx", "wb") { |f| f.print pfx.to_der }
-        File.open(file_path + ".der", "wb") { |f| f.print Base64.strict_encode64(pfx.to_der) }
+        File.open(file_path + ".b64", "wb") { |f| f.print Base64.strict_encode64(pfx.to_der) }
       end
 
       def run
@@ -119,7 +119,7 @@ class Chef
           write_certificate_to_file cert, file_path, rsa_key
           ui.info "Generated Certificates:"
           ui.info " PKCS12 FORMAT (needed on the server machine, contains private key): #{file_path}.pfx"
-          ui.info " BASE64 ENCODED (used for creating SSL listener through cloud provider api, contains private key): #{file_path}.der"
+          ui.info " BASE64 ENCODED (used for creating SSL listener through cloud provider api, contains private key): #{file_path}.b64"
           ui.info " PEM FORMAT (required by the client to connect to the server): #{file_path}.pem"
           ui.info "Certificate Thumbprint: #{@thumbprint.to_s.upcase}"
         rescue => e

--- a/spec/unit/knife/windows_cert_generate_spec.rb
+++ b/spec/unit/knife/windows_cert_generate_spec.rb
@@ -54,9 +54,9 @@ describe Chef::Knife::WindowsCertGenerate do
     expect(@certgen).to receive(:generate_certificate)
     expect(@certgen).to receive(:write_certificate_to_file)
     expect(@certgen.ui).to receive(:info).with("Generated Certificates:")
-    expect(@certgen.ui).to receive(:info).with(" PKCS12 FORMAT (needed on the server machine, contains private key): winrmcert.pfx")
-    expect(@certgen.ui).to receive(:info).with(" BASE64 ENCODED (used for creating SSL listener through cloud provider api, contains private key): winrmcert.b64")
-    expect(@certgen.ui).to receive(:info).with(" PEM FORMAT (required by the client to connect to the server): winrmcert.pem")
+    expect(@certgen.ui).to receive(:info).with("- winrmcert.pfx - PKCS12 format keypair. Contains both the public and private keys, usually used on the server.")
+    expect(@certgen.ui).to receive(:info).with("- winrmcert.b64 - Base64 encoded PKCS12 keypair. Contains both the public and private keys, for upload to the Cloud REST API. e.g. Azure")
+    expect(@certgen.ui).to receive(:info).with("- winrmcert.pem - Base64 encoded public certificate only. Required by the client to connect to the server.")
     @certgen.thumbprint = "TEST_THUMBPRINT"
     expect(@certgen.ui).to receive(:info).with("Certificate Thumbprint: TEST_THUMBPRINT")
     @certgen.run

--- a/spec/unit/knife/windows_cert_generate_spec.rb
+++ b/spec/unit/knife/windows_cert_generate_spec.rb
@@ -55,7 +55,7 @@ describe Chef::Knife::WindowsCertGenerate do
     expect(@certgen).to receive(:write_certificate_to_file)
     expect(@certgen.ui).to receive(:info).with("Generated Certificates:")
     expect(@certgen.ui).to receive(:info).with(" PKCS12 FORMAT (needed on the server machine, contains private key): winrmcert.pfx")
-    expect(@certgen.ui).to receive(:info).with(" BASE64 ENCODED (used for creating SSL listener through cloud provider api, contains private key): winrmcert.der")
+    expect(@certgen.ui).to receive(:info).with(" BASE64 ENCODED (used for creating SSL listener through cloud provider api, contains private key): winrmcert.b64")
     expect(@certgen.ui).to receive(:info).with(" PEM FORMAT (required by the client to connect to the server): winrmcert.pem")
     @certgen.thumbprint = "TEST_THUMBPRINT"
     expect(@certgen.ui).to receive(:info).with("Certificate Thumbprint: TEST_THUMBPRINT")


### PR DESCRIPTION
Fix for issue https://github.com/chef/knife-windows/issues/163

Azure requires base64 encoded `pfx` file: https://msdn.microsoft.com/en-us/library/azure/ee460817.aspx
Since we were using `der` file for that purpose only, we should make the extension accurate.