### PR TITLE
move Chef::Knife::Bootstrap require to base so both winrm + ssh will get them

### DIFF
--- a/lib/chef/knife/bootstrap_windows_base.rb
+++ b/lib/chef/knife/bootstrap_windows_base.rb
@@ -17,6 +17,7 @@
 #
 
 require 'chef/knife'
+require 'chef/knife/bootstrap'
 require 'chef/encrypted_data_bag_item'
 require 'chef/knife/core/windows_bootstrap_context'
 

--- a/lib/chef/knife/bootstrap_windows_winrm.rb
+++ b/lib/chef/knife/bootstrap_windows_winrm.rb
@@ -19,7 +19,6 @@
 require 'chef/knife/bootstrap_windows_base'
 require 'chef/knife/winrm'
 require 'chef/knife/winrm_base'
-require 'chef/knife/bootstrap'
 
 class Chef
   class Knife


### PR DESCRIPTION
Fixes #162 in master. snuck a workaround into 0.8.3-release in b9b2a0e81356e384bf157de3a1b8340a591c91c2 .