### PR TITLE
Add connection_timeout property that defaults to 30 minutes but can be overrid...

### DIFF
--- a/lib/chef/knife/winrm.rb
+++ b/lib/chef/knife/winrm.rb
@@ -185,7 +185,7 @@ class Chef
           session_opts[:service] = locate_config_value(:kerberos_service) if locate_config_value(:kerberos_service)
           session_opts[:ca_trust_path] = locate_config_value(:ca_trust_file) if locate_config_value(:ca_trust_file)
           #30 min (Default) OperationTimeout for long bootstraps fix for KNIFE_WINDOWS-8
-          session_opts[:operation_timeout] = locate_config_value(:connection_timeout).to_i if locate_config_value(:connection_timeout)
+          session_opts[:operation_timeout] = locate_config_value(:session_timeout).to_i * 60 if locate_config_value(:session_timeout)
           session_opts[:no_ssl_peer_verification] = no_ssl_peer_verification?(session_opts[:ca_trust_path])
           warn_no_ssl_peer_verification if session_opts[:no_ssl_peer_verification]
 

--- a/lib/chef/knife/winrm.rb
+++ b/lib/chef/knife/winrm.rb
@@ -184,7 +184,8 @@ class Chef
           session_opts[:realm] = locate_config_value(:kerberos_realm) if locate_config_value(:kerberos_realm)
           session_opts[:service] = locate_config_value(:kerberos_service) if locate_config_value(:kerberos_service)
           session_opts[:ca_trust_path] = locate_config_value(:ca_trust_file) if locate_config_value(:ca_trust_file)
-          session_opts[:operation_timeout] = 1800 # 30 min OperationTimeout for long bootstraps fix for KNIFE_WINDOWS-8
+          #30 min (Default) OperationTimeout for long bootstraps fix for KNIFE_WINDOWS-8
+          session_opts[:operation_timeout] = locate_config_value(:connection_timeout).to_i if locate_config_value(:connection_timeout)
           session_opts[:no_ssl_peer_verification] = no_ssl_peer_verification?(session_opts[:ca_trust_path])
           warn_no_ssl_peer_verification if session_opts[:no_ssl_peer_verification]
 

--- a/lib/chef/knife/winrm_base.rb
+++ b/lib/chef/knife/winrm_base.rb
@@ -105,10 +105,10 @@ class Chef
             :default => "negotiate",
             :proc => Proc.new { |protocol| Chef::Config[:knife][:winrm_authentication_protocol] = protocol }
 						
-          option :connection_timeout,
-            :long => "--connection-timeout Seconds",
-            :description => "The timeout for the client to wait for the WinRM connection to complete",
-            :default => 1800
+          option :session_timeout,
+            :long => "--session-timeout Minutes",
+            :description => "The timeout for the client for the maximum length of the WinRM session",
+            :default => 30
         end
       end
 

--- a/lib/chef/knife/winrm_base.rb
+++ b/lib/chef/knife/winrm_base.rb
@@ -104,6 +104,11 @@ class Chef
             :description => "The authentication protocol used during WinRM communication. The supported protocols are #{WINRM_AUTH_PROTOCOL_LIST.join(',')}. Default is 'negotiate'.",
             :default => "negotiate",
             :proc => Proc.new { |protocol| Chef::Config[:knife][:winrm_authentication_protocol] = protocol }
+						
+          option :connection_timeout,
+            :long => "--connection-timeout Seconds",
+            :description => "The timeout for the client to wait for the WinRM connection to complete",
+            :default => 1800
         end
       end
 

--- a/spec/unit/knife/winrm_spec.rb
+++ b/spec/unit/knife/winrm_spec.rb
@@ -111,8 +111,8 @@ describe Chef::Knife::Winrm do
           winrm_command_http.configure_chef
           winrm_command_http.configure_session
         end
-
-        it "set operation timeout" do
+        
+        it "set operation timeout and verify default" do
           Chef::Config[:knife] = {:winrm_transport => 'plaintext'}
           allow(Chef::Platform).to receive(:windows?).and_return(false)
           expect(Chef::Knife::Winrm::Session).to receive(:new).with(hash_including(:transport => :plaintext)).and_call_original
@@ -131,6 +131,19 @@ describe Chef::Knife::Winrm do
           winrm_command_http.set_defaults
           winrm_command_http.configure_chef
           winrm_command_http.configure_session
+        end
+        
+        let(:winrm_command_timeout) { Chef::Knife::Winrm.new(['-m', 'localhost', '-x', 'testuser', '-P', 'testpassword','--winrm-transport', 'plaintext', '--connection-timeout', '10', 'echo helloworld'])        }
+         
+         it "set operation timeout and verify 10 second  timeout" do
+          Chef::Config[:knife] = {winrm_transport: 'plaintext'}
+          allow(Chef::Platform).to receive(:windows?).and_return(false)
+          expect(Chef::Knife::Winrm::Session).to receive(:new).with(hash_including(:transport => :plaintext)).and_call_original
+          expect(WinRM::WinRMWebService).to receive(:new).with('http://localhost:5985/wsman', anything, anything).and_return(@winrm_session)
+          expect(@winrm_session).to receive(:set_timeout).with(10)
+          winrm_command_timeout.set_defaults
+          winrm_command_timeout.configure_chef
+          winrm_command_timeout.configure_session
         end
 
         let(:winrm_command_https) { Chef::Knife::Winrm.new(['-m', 'localhost', '-x', 'testuser', '-P', 'testpassword', '--winrm-transport', 'ssl', 'echo helloworld'])
@@ -305,7 +318,7 @@ describe Chef::Knife::Winrm do
             @winrm.config[:winrm_user] = "domain\\testuser"
             allow(Chef::Platform).to receive(:windows?).and_return(true)
             allow(@winrm).to receive(:require).with('winrm-s').and_return(true)
-            expect(@winrm).to receive(:create_winrm_session).with({:user=>"domain\\testuser", :password=>"testpassword", :port=>"5985", :operation_timeout=>1800, :no_ssl_peer_verification => false, :basic_auth_only=>false, :transport=>:sspinegotiate, :disable_sspi=>false, :host=>"localhost"})
+            expect(@winrm).to receive(:create_winrm_session).with({:user=>"domain\\testuser", :password=>"testpassword", :port=>"5985", :no_ssl_peer_verification => false, :basic_auth_only=>false, :transport=>:sspinegotiate, :disable_sspi=>false, :host=>"localhost"})
             exit_code = @winrm.run
           end
 
@@ -313,7 +326,7 @@ describe Chef::Knife::Winrm do
             Chef::Config[:knife][:winrm_authentication_protocol] = "negotiate"
             allow(Chef::Platform).to receive(:windows?).and_return(false)
             allow(@winrm).to receive(:exit)
-            expect(@winrm).to receive(:create_winrm_session).with({:user=>"testuser", :password=>"testpassword", :port=>"5985", :operation_timeout=>1800, :no_ssl_peer_verification=>false, :basic_auth_only=>false, :transport=>:plaintext, :disable_sspi=>true, :host=>"localhost"})
+            expect(@winrm).to receive(:create_winrm_session).with({:user=>"testuser", :password=>"testpassword", :port=>"5985", :no_ssl_peer_verification=>false, :basic_auth_only=>false, :transport=>:plaintext, :disable_sspi=>true, :host=>"localhost"})
             exit_code = @winrm.run
           end
 
@@ -366,7 +379,7 @@ describe Chef::Knife::Winrm do
             Chef::Config[:knife][:winrm_transport] = "ssl"
             @winrm.config[:winrm_user] = "domain\\testuser"
             allow(Chef::Platform).to receive(:windows?).and_return(true)
-            expect(@winrm).to receive(:create_winrm_session).with({:user=>"domain\\testuser", :password=>"testpassword", :port=>"5986", :operation_timeout=>1800, :no_ssl_peer_verification=>false, :basic_auth_only=>true, :transport=>:ssl, :disable_sspi=>true, :host=>"localhost"})
+            expect(@winrm).to receive(:create_winrm_session).with({:user=>"domain\\testuser", :password=>"testpassword", :port=>"5986", :no_ssl_peer_verification=>false, :basic_auth_only=>true, :transport=>:ssl, :disable_sspi=>true, :host=>"localhost"})
             expect(@winrm).to_not receive(:require).with('winrm-s')
             exit_code = @winrm.run
           end

--- a/spec/unit/knife/winrm_spec.rb
+++ b/spec/unit/knife/winrm_spec.rb
@@ -133,14 +133,14 @@ describe Chef::Knife::Winrm do
           winrm_command_http.configure_session
         end
         
-        let(:winrm_command_timeout) { Chef::Knife::Winrm.new(['-m', 'localhost', '-x', 'testuser', '-P', 'testpassword','--winrm-transport', 'plaintext', '--connection-timeout', '10', 'echo helloworld'])        }
+        let(:winrm_command_timeout) { Chef::Knife::Winrm.new(['-m', 'localhost', '-x', 'testuser', '-P', 'testpassword','--winrm-transport', 'plaintext', '--session-timeout', '10', 'echo helloworld'])        }
          
-         it "set operation timeout and verify 10 second  timeout" do
+         it "set operation timeout and verify 10 Minute timeout" do
           Chef::Config[:knife] = {winrm_transport: 'plaintext'}
           allow(Chef::Platform).to receive(:windows?).and_return(false)
           expect(Chef::Knife::Winrm::Session).to receive(:new).with(hash_including(:transport => :plaintext)).and_call_original
           expect(WinRM::WinRMWebService).to receive(:new).with('http://localhost:5985/wsman', anything, anything).and_return(@winrm_session)
-          expect(@winrm_session).to receive(:set_timeout).with(10)
+          expect(@winrm_session).to receive(:set_timeout).with(600)
           winrm_command_timeout.set_defaults
           winrm_command_timeout.configure_chef
           winrm_command_timeout.configure_session


### PR DESCRIPTION
...den on the CLI.


This PR along with the new winrm-s [PR \#22](https://github.com/chef/winrm-s/pull/22) and issue[https://github.com/chef/winrm-s/issues/21] will get knife-windows to have a configurable timeout for both the operation timeout and receive_timeout.

Both of these are required to enable greater than 60 minute winrm sessions  For reference the WinRM 1.3 PR(https://github.com/WinRb/WinRM/pull/108)

PS -
Depending on the integration of the new WinRM in winrm-s gem, we might need to do one more commit here in the gemspec file...