### PR TITLE
Invalid mkdir command in bootstrap template

### DIFF
--- a/lib/chef/knife/bootstrap/windows-chef-client-msi.erb
+++ b/lib/chef/knife/bootstrap/windows-chef-client-msi.erb
@@ -199,7 +199,7 @@ echo Validation key written.
 
 <% if(Gem::Specification.find_by_name('chef').version.version.to_f >= 12) %>
 <% unless trusted_certs.empty? -%>
-mkdir -p C:/chef/trusted_certs
+mkdir <%= bootstrap_directory %>\trusted_certs
 <%= trusted_certs %>
 <% end -%>
 <% end -%>


### PR DESCRIPTION
The command to create trusted_certs folder during bootstrapping seems to have been copied from a UNIX bootstrapping template, which won't run properly in a Windows batch file.