### PR TITLE
Finish fixes for #133

### DIFF
--- a/lib/chef/knife/bootstrap/windows-chef-client-msi.erb
+++ b/lib/chef/knife/bootstrap/windows-chef-client-msi.erb
@@ -199,7 +199,7 @@ echo Validation key written.
 
 <% if(Gem::Specification.find_by_name('chef').version.version.to_f >= 12) %>
 <% unless trusted_certs.empty? -%>
-mkdir -p C:/chef/trusted_certs
+mkdir C:\chef\trusted_certs
 <%= trusted_certs %>
 <% end -%>
 <% end -%>

--- a/lib/chef/knife/bootstrap_windows_base.rb
+++ b/lib/chef/knife/bootstrap_windows_base.rb
@@ -99,6 +99,21 @@ class Chef
             :long => "--auth-timeout MINUTES",
             :description => "The maximum time in minutes to wait to for authentication over the transport to the node to succeed. The default value is 2 minutes.",
             :default => 2
+
+          option :node_ssl_verify_mode,
+          :long        => "--node-ssl-verify-mode [peer|none]",
+          :description => "Whether or not to verify the SSL cert for all HTTPS requests.",
+          :proc        => Proc.new { |v|
+            valid_values = ["none", "peer"]
+            unless valid_values.include?(v)
+              raise "Invalid value '#{v}' for --node-ssl-verify-mode. Valid values are: #{valid_values.join(", ")}"
+            end
+          }
+
+          option :node_verify_api_cert,
+          :long        => "--[no-]node-verify-api-cert",
+          :description => "Verify the SSL cert for HTTPS requests to the Chef server API.",
+          :boolean     => true
         end
       end
 

--- a/lib/chef/knife/core/windows_bootstrap_context.rb
+++ b/lib/chef/knife/core/windows_bootstrap_context.rb
@@ -265,7 +265,7 @@ WGET_PS
           if @chef_config[:trusted_certs_dir]
             Dir.glob(File.join(PathHelper.escape_glob(@chef_config[:trusted_certs_dir]), "*.{crt,pem}")).each do |cert|
               content << "> #{bootstrap_directory}/trusted_certs/#{File.basename(cert)} (\n" +
-                         IO.read(File.expand_path(cert)) + "\n)\n"
+                         escape_and_echo(IO.read(File.expand_path(cert))) + "\n)\n"
             end
           end
           content


### PR DESCRIPTION
I tested these changes and they work. I can now manage SSL verification while bootstrapping a Windows node.