### PR TITLE
Fix trusted_certs regression introduced by c09a2b2

### DIFF
--- a/lib/chef/knife/bootstrap/windows-chef-client-msi.erb
+++ b/lib/chef/knife/bootstrap/windows-chef-client-msi.erb
@@ -197,11 +197,9 @@ echo Validation key written.
 )
 <% end -%>
 
-<% if(Gem::Specification.find_by_name('chef').version.version.to_f >= 12) %>
-<% unless trusted_certs.empty? -%>
+<% unless trusted_certs_script.empty? -%>
 mkdir <%= bootstrap_directory %>\trusted_certs
-<%= trusted_certs %>
-<% end -%>
+<%= trusted_certs_script %>
 <% end -%>
 
 <%# Generate Ohai Hints -%>

--- a/lib/chef/knife/core/windows_bootstrap_context.rb
+++ b/lib/chef/knife/core/windows_bootstrap_context.rb
@@ -126,10 +126,8 @@ CONFIG
             client_rb << %Q{encrypted_data_bag_secret "c:/chef/encrypted_data_bag_secret"\n}
           end
 
-          if(Gem::Specification.find_by_name('chef').version.version.to_f >= 12)
-            unless trusted_certs.empty?
-              client_rb << %Q{trusted_certs_dir "c:/chef/trusted_certs"\n}
-            end
+          unless trusted_certs_script.empty?
+            client_rb << %Q{trusted_certs_dir "c:/chef/trusted_certs"\n}
           end
 
           escape_and_echo(client_rb)


### PR DESCRIPTION
The helper for accessing trusted_certs content was renamed to `trusted_certs_script` in 583a2b2. For some reason this was changed back to `trusted_certs` in commit c09a2b2. Without this fix bootstrapping fails with:

    NameError: undefined local variable or method `trusted_certs' for #<Chef::Knife::Core::WindowsBootstrapContext:0x007fcd54522910>

/cc @adamx @btm