### PR TITLE
Updated code for setting winrm port default option

### DIFF
--- a/lib/chef/knife/winrm_base.rb
+++ b/lib/chef/knife/winrm_base.rb
@@ -56,7 +56,8 @@ class Chef
             :long => "--winrm-transport TRANSPORT",
             :description => "The WinRM transport type.  valid choices are [ssl, plaintext]",
             :default => 'plaintext',
-            :proc => Proc.new { |transport| Chef::Config[:knife][:winrm_port] = '5986' if transport == 'ssl'; Chef::Config[:knife][:winrm_transport] = transport }
+            :proc => Proc.new { |transport| Chef::Config[:knife][:winrm_port] = '5986' if transport == 'ssl'
+                                Chef::Config[:knife][:winrm_transport] = transport }
 
           option :winrm_port,
             :short => "-p PORT",

--- a/lib/chef/knife/winrm_base.rb
+++ b/lib/chef/knife/winrm_base.rb
@@ -51,23 +51,24 @@ class Chef
             :description => "The WinRM password",
             :proc => Proc.new { |key| Chef::Config[:knife][:winrm_password] = key }
 
+          option :winrm_transport,
+            :short => "-t TRANSPORT",
+            :long => "--winrm-transport TRANSPORT",
+            :description => "The WinRM transport type.  valid choices are [ssl, plaintext]",
+            :default => 'plaintext',
+            :proc => Proc.new { |transport| Chef::Config[:knife][:winrm_transport] = transport; Chef::Config[:knife][:winrm_port] = '5986' if transport == 'ssl' }
+
           option :winrm_port,
             :short => "-p PORT",
             :long => "--winrm-port PORT",
             :description => "The WinRM port, by default this is '5985' for 'plaintext' and '5986' for 'ssl' winrm transport",
+            :default => '5985',
             :proc => Proc.new { |key| Chef::Config[:knife][:winrm_port] = key }
 
           option :identity_file,
             :short => "-i IDENTITY_FILE",
             :long => "--identity-file IDENTITY_FILE",
             :description => "The SSH identity file used for authentication"
-
-          option :winrm_transport,
-            :short => "-t TRANSPORT",
-            :long => "--winrm-transport TRANSPORT",
-            :description => "The WinRM transport type.  valid choices are [ssl, plaintext]",
-            :default => 'plaintext',
-            :proc => Proc.new { |transport| Chef::Config[:knife][:winrm_transport] = transport }
 
           option :kerberos_keytab_file,
             :short => "-i KEYTAB_FILE",

--- a/lib/chef/knife/winrm_base.rb
+++ b/lib/chef/knife/winrm_base.rb
@@ -56,7 +56,7 @@ class Chef
             :long => "--winrm-transport TRANSPORT",
             :description => "The WinRM transport type.  valid choices are [ssl, plaintext]",
             :default => 'plaintext',
-            :proc => Proc.new { |transport| Chef::Config[:knife][:winrm_transport] = transport; Chef::Config[:knife][:winrm_port] = '5986' if transport == 'ssl' }
+            :proc => Proc.new { |transport| Chef::Config[:knife][:winrm_port] = '5986' if transport == 'ssl'; Chef::Config[:knife][:winrm_transport] = transport }
 
           option :winrm_port,
             :short => "-p PORT",

--- a/lib/chef/knife/winrm_knife_base.rb
+++ b/lib/chef/knife/winrm_knife_base.rb
@@ -100,15 +100,6 @@ class Chef
             @session_opts = {}
             @session_opts[:user] = locate_config_value(:winrm_user)
             @session_opts[:password] = locate_config_value(:winrm_password)
-
-            # set default winrm_port = 5986 for ssl transport
-            # set default winrm_port = 5985 for plaintext transport
-            case locate_config_value(:winrm_transport)
-            when 'ssl'
-              Chef::Config[:knife][:winrm_port] = "5986"
-            else
-              Chef::Config[:knife][:winrm_port] = "5985"
-            end
             @session_opts[:port] = locate_config_value(:winrm_port)
             #30 min (Default) OperationTimeout for long bootstraps fix for KNIFE_WINDOWS-8
             @session_opts[:operation_timeout] = locate_config_value(:session_timeout).to_i * 60 if locate_config_value(:session_timeout)

--- a/lib/chef/knife/winrm_knife_base.rb
+++ b/lib/chef/knife/winrm_knife_base.rb
@@ -101,6 +101,7 @@ class Chef
             @session_opts[:user] = locate_config_value(:winrm_user)
             @session_opts[:password] = locate_config_value(:winrm_password)
             @session_opts[:port] = locate_config_value(:winrm_port)
+
             #30 min (Default) OperationTimeout for long bootstraps fix for KNIFE_WINDOWS-8
             @session_opts[:operation_timeout] = locate_config_value(:session_timeout).to_i * 60 if locate_config_value(:session_timeout)
           end

--- a/spec/unit/knife/winrm_spec.rb
+++ b/spec/unit/knife/winrm_spec.rb
@@ -361,6 +361,7 @@ describe Chef::Knife::Winrm do
             @winrm.config[:winrm_authentication_protocol] = "basic"
             @winrm.config[:winrm_transport] = "ssl"
             @winrm.config[:winrm_user] = "domain\\testuser"
+            @winrm.config[:winrm_port] = "5986"
             allow(Chef::Platform).to receive(:windows?).and_return(true)
             expect(@winrm).to receive(:create_winrm_session).with({:user=>"domain\\testuser", :password=>"testpassword", :port=>"5986", :no_ssl_peer_verification=>false, :basic_auth_only=>true, :operation_timeout=>1800, :transport=>:ssl, :disable_sspi=>true, :host=>"localhost"})
             expect(@winrm).to_not receive(:require).with('winrm-s')


### PR DESCRIPTION
:default setting for --winrm-port option was removed on master and its causing to set winrm_port to nil in knife ec2 server create. Updated code to set default option of --winrm-port to 5985 in option and if --winrm-transport value is ssl then to 5986. And removed set default part from winrm_knife_base.rb