### PR TITLE
Possibility to bootstrap with install as service option

### DIFF
--- a/lib/chef/knife/bootstrap_windows_base.rb
+++ b/lib/chef/knife/bootstrap_windows_base.rb
@@ -66,6 +66,11 @@ class Chef
             :description => "Bootstrap a distro using a template",
             :default => "windows-chef-client-msi"
 
+          option :install_as_service,
+            :long => "--install-as-service",
+            :description => "Install chef-client as service in windows machine",
+            :default => false
+
           option :template_file,
             :long => "--template-file TEMPLATE",
             :description => "Full path to location of template to use",

--- a/lib/chef/knife/bootstrap_windows_base.rb
+++ b/lib/chef/knife/bootstrap_windows_base.rb
@@ -66,11 +66,6 @@ class Chef
             :description => "Bootstrap a distro using a template",
             :default => "windows-chef-client-msi"
 
-          option :install_as_service,
-            :long => "--install-as-service",
-            :description => "Install chef-client as service in windows machine",
-            :default => false
-
           option :template_file,
             :long => "--template-file TEMPLATE",
             :description => "Full path to location of template to use",
@@ -127,6 +122,11 @@ class Chef
             :long => "--msi_url URL",
             :description => "Location of the Chef Client MSI. The default templates will prefer to download from this location. The MSI will be downloaded from chef.io if not provided.",
             :default => ''
+
+          option :install_as_service,
+            :long => "--install-as-service",
+            :description => "Install chef-client as service in windows machine",
+            :default => false
         end
       end
 

--- a/lib/chef/knife/core/windows_bootstrap_context.rb
+++ b/lib/chef/knife/core/windows_bootstrap_context.rb
@@ -289,7 +289,11 @@ WGET_PS
         private
 
         def install_command(executor_quote)
-          "msiexec /qn /log #{executor_quote}%CHEF_CLIENT_MSI_LOG_PATH%#{executor_quote} /i #{executor_quote}%LOCAL_DESTINATION_MSI_PATH%#{executor_quote}"
+          if @config[:install_as_service] || @knife_config[:install_as_service]
+            "msiexec /qn /log #{executor_quote}%CHEF_CLIENT_MSI_LOG_PATH%#{executor_quote} /i #{executor_quote}%LOCAL_DESTINATION_MSI_PATH%#{executor_quote} ADDLOCAL=#{executor_quote}ChefClientFeature,ChefServiceFeature#{executor_quote}"
+          else              
+            "msiexec /qn /log #{executor_quote}%CHEF_CLIENT_MSI_LOG_PATH%#{executor_quote} /i #{executor_quote}%LOCAL_DESTINATION_MSI_PATH%#{executor_quote}"
+          end
         end
 
         # Returns a string for copying the trusted certificates on the workstation to the system being bootstrapped

--- a/lib/chef/knife/core/windows_bootstrap_context.rb
+++ b/lib/chef/knife/core/windows_bootstrap_context.rb
@@ -289,7 +289,7 @@ WGET_PS
         private
 
         def install_command(executor_quote)
-          if @config[:install_as_service] || @knife_config[:install_as_service]
+          if @config[:install_as_service]
             "msiexec /qn /log #{executor_quote}%CHEF_CLIENT_MSI_LOG_PATH%#{executor_quote} /i #{executor_quote}%LOCAL_DESTINATION_MSI_PATH%#{executor_quote} ADDLOCAL=#{executor_quote}ChefClientFeature,ChefServiceFeature#{executor_quote}"
           else              
             "msiexec /qn /log #{executor_quote}%CHEF_CLIENT_MSI_LOG_PATH%#{executor_quote} /i #{executor_quote}%LOCAL_DESTINATION_MSI_PATH%#{executor_quote}"


### PR DESCRIPTION
Allow choose how to install chef-client, as regular appplication or as service
Add --install-as-service option in your bootstrap command line and MSI will install and enable the service on Windows.
it should resolve #202 