### PR TITLE
Added validator less bootstrap support for knife bootstrap windows winrm

### DIFF
--- a/lib/chef/knife/bootstrap/windows-chef-client-msi.erb
+++ b/lib/chef/knife/bootstrap/windows-chef-client-msi.erb
@@ -188,11 +188,20 @@ goto install
 @endlocal
 
 @echo off
+
+<% if client_pem -%>
+> <%= bootstrap_directory %>\client.pem (
+ <%= escape_and_echo(::File.read(::File.expand_path(client_pem))) %>
+)
+<% end -%>
+
 echo Writing validation key...
 
+<% if validation_key -%>
 > <%= bootstrap_directory %>\validation.pem (
- <%= validation_key %>
+ <%= escape_and_echo(validation_key) %>
 )
+<% end -%>
 
 echo Validation key written.
 @echo on

--- a/lib/chef/knife/bootstrap_windows_base.rb
+++ b/lib/chef/knife/bootstrap_windows_base.rb
@@ -188,8 +188,21 @@ class Chef
         STDOUT.sync = STDERR.sync = true
 
         if (Chef::Config[:validation_key] && !File.exist?(File.expand_path(Chef::Config[:validation_key])))
+
+          unless locate_config_value(:winrm_authentication_protocol) == 'negotiate' &&
+              (locate_config_value(:winrm_transport) == 'ssl' || locate_config_value(:winrm_transport) == 'plaintext') && (Chef::Platform.windows?)
+            ui.error("Validator less bootstrap only supported with negotiate authentication protocol and ssl/plaintext transport")
+            ui.info("Negotiate protocol with plaintext transport is only supported when this tool is invoked from windows-based system")
+            exit 1
+          end
+
+          unless locate_config_value(:chef_node_name)
+            ui.error("You must pass a node name with -N when bootstrapping with user credentials")
+            exit 1
+          end
+
           client_builder.run
-          bootstrap_context.client_pem = client_builder.client_path
+          bootstrap_context.client_pem = client_builder.client_pathqqq
         else
           ui.info("Doing old-style registration with the validation key at #{Chef::Config[:validation_key]}...")
           ui.info("Delete your validation key in order to use your user credentials instead")

--- a/lib/chef/knife/bootstrap_windows_base.rb
+++ b/lib/chef/knife/bootstrap_windows_base.rb
@@ -188,6 +188,13 @@ class Chef
         STDOUT.sync = STDERR.sync = true
 
         if (Chef::Config[:validation_key] && !File.exist?(File.expand_path(Chef::Config[:validation_key])))
+          # require 'pry'
+          # binding.pry
+
+          if Chef::VERSION.split('.').first.to_i == 11
+            ui.error("Unable to find validation key. Please verify your configuration file for validation_key config value.")
+            exit 1
+          end
 
           unless locate_config_value(:chef_node_name)
             ui.error("You must pass a node name with -N when bootstrapping with user credentials")

--- a/lib/chef/knife/bootstrap_windows_base.rb
+++ b/lib/chef/knife/bootstrap_windows_base.rb
@@ -161,12 +161,15 @@ class Chef
         IO.read(template).chomp
       end
 
+      def bootstrap_context
+        @bootstrap_context ||= Knife::Core::WindowsBootstrapContext.new(config, config[:run_list], Chef::Config,secret)
+      end
+
       def render_template(template=nil)
         if config[:secret_file]
           config[:secret] = Chef::EncryptedDataBagItem.load_secret(config[:secret_file])
         end
-        context = Knife::Core::WindowsBootstrapContext.new(config, config[:run_list], Chef::Config)
-        Erubis::Eruby.new(template).evaluate(context)
+        Erubis::Eruby.new(template).evaluate(bootstrap_context)
       end
 
       def bootstrap(proto=nil)
@@ -175,15 +178,23 @@ class Chef
           config[:secret_file] ||= Chef::Config[:knife][:encrypted_data_bag_secret_file]
           config[:secret] ||= Chef::Config[:knife][:encrypted_data_bag_secret]
         end
-        
-        validate_name_args!
 
+        validate_name_args!
 
         @node_name = Array(@name_args).first
         # back compat--templates may use this setting:
         config[:server_name] = @node_name
 
         STDOUT.sync = STDERR.sync = true
+
+        if (Chef::Config[:validation_key] && !File.exist?(File.expand_path(Chef::Config[:validation_key])))
+          client_builder.run
+          bootstrap_context.client_pem = client_builder.client_path
+        else
+          ui.info("Doing old-style registration with the validation key at #{Chef::Config[:validation_key]}...")
+          ui.info("Delete your validation key in order to use your user credentials instead")
+          ui.info("")
+        end
 
         wait_for_remote_response( config[:auth_timeout].to_i )
         ui.info("Bootstrapping Chef on #{ui.color(@node_name, :bold)}")
@@ -202,6 +213,7 @@ class Chef
         # execute the bootstrap.bat file
         bootstrap_command_result = run_command(bootstrap_command)
         ui.error("Bootstrap command returned #{bootstrap_command_result}") if bootstrap_command_result != 0
+
         bootstrap_command_result
       end
 

--- a/lib/chef/knife/bootstrap_windows_base.rb
+++ b/lib/chef/knife/bootstrap_windows_base.rb
@@ -202,7 +202,7 @@ class Chef
           end
 
           client_builder.run
-          bootstrap_context.client_pem = client_builder.client_pathqqq
+          bootstrap_context.client_pem = client_builder.client_path
         else
           ui.info("Doing old-style registration with the validation key at #{Chef::Config[:validation_key]}...")
           ui.info("Delete your validation key in order to use your user credentials instead")

--- a/lib/chef/knife/bootstrap_windows_base.rb
+++ b/lib/chef/knife/bootstrap_windows_base.rb
@@ -162,7 +162,7 @@ class Chef
       end
 
       def bootstrap_context
-        @bootstrap_context ||= Knife::Core::WindowsBootstrapContext.new(config, config[:run_list], Chef::Config,secret)
+        @bootstrap_context ||= Knife::Core::WindowsBootstrapContext.new(config, config[:run_list], Chef::Config)
       end
 
       def render_template(template=nil)

--- a/lib/chef/knife/bootstrap_windows_base.rb
+++ b/lib/chef/knife/bootstrap_windows_base.rb
@@ -189,13 +189,6 @@ class Chef
 
         if (Chef::Config[:validation_key] && !File.exist?(File.expand_path(Chef::Config[:validation_key])))
 
-          unless locate_config_value(:winrm_authentication_protocol) == 'negotiate' &&
-              (locate_config_value(:winrm_transport) == 'ssl' || locate_config_value(:winrm_transport) == 'plaintext') && (Chef::Platform.windows?)
-            ui.error("Validator less bootstrap only supported with negotiate authentication protocol and ssl/plaintext transport")
-            ui.info("Negotiate protocol with plaintext transport is only supported when this tool is invoked from windows-based system")
-            exit 1
-          end
-
           unless locate_config_value(:chef_node_name)
             ui.error("You must pass a node name with -N when bootstrapping with user credentials")
             exit 1

--- a/lib/chef/knife/bootstrap_windows_winrm.rb
+++ b/lib/chef/knife/bootstrap_windows_winrm.rb
@@ -19,6 +19,8 @@
 require 'chef/knife/bootstrap_windows_base'
 require 'chef/knife/winrm'
 require 'chef/knife/winrm_base'
+require 'chef/knife/winrm_knife_base'
+
 
 class Chef
   class Knife
@@ -26,6 +28,8 @@ class Chef
 
       include Chef::Knife::BootstrapWindowsBase
       include Chef::Knife::WinrmBase
+      include Chef::Knife::WinrmCommandSharedFunctions
+
 
       deps do
         require 'chef/knife/core/windows_bootstrap_context'
@@ -37,6 +41,17 @@ class Chef
       banner "knife bootstrap windows winrm FQDN (options)"
 
       def run
+        if (Chef::Config[:validation_key] && !File.exist?(File.expand_path(Chef::Config[:validation_key])))
+
+          if !negotiate_auth? && !(locate_config_value(:winrm_transport) == 'ssl')
+            ui.error("Validatorless bootstrap only supported with negotiate authentication protocol and ssl/plaintext transport")
+            exit 1
+          elsif !(Chef::Platform.windows?) && negotiate_auth?
+            ui.error("Negotiate protocol with plaintext transport is only supported when this tool is invoked from windows based system")
+            exit 1
+          end
+
+        end
         bootstrap
       end
 

--- a/lib/chef/knife/bootstrap_windows_winrm.rb
+++ b/lib/chef/knife/bootstrap_windows_winrm.rb
@@ -114,4 +114,3 @@ class Chef
     end
   end
 end
-

--- a/lib/chef/knife/core/windows_bootstrap_context.rb
+++ b/lib/chef/knife/core/windows_bootstrap_context.rb
@@ -22,6 +22,7 @@ require 'chef/knife/core/bootstrap_context'
 require 'knife-windows/path_helper'
 # require 'chef/util/path_helper'
 
+
 class Chef
   class Knife
     module Core
@@ -34,10 +35,13 @@ class Chef
       class WindowsBootstrapContext < BootstrapContext
         PathHelper = ::Knife::Windows::PathHelper
 
+        attr_accessor :client_pem
+
         def initialize(config, run_list, chef_config, secret=nil)
           @config       = config
           @run_list     = run_list
           @chef_config  = chef_config
+          @secret       = secret
           # Compatibility with Chef 12 and Chef 11 versions
           begin
             # Pass along the secret parameter for Chef 12
@@ -49,7 +53,11 @@ class Chef
         end
 
         def validation_key
-          escape_and_echo(super)
+          if File.exist?(File.expand_path(@chef_config[:validation_key]))
+            IO.read(File.expand_path(@chef_config[:validation_key]))
+          else
+            false
+          end
         end
 
         def secret
@@ -67,8 +75,6 @@ log_location     STDOUT
 
 chef_server_url  "#{@chef_config[:chef_server_url]}"
 validation_client_name "#{@chef_config[:validation_client_name]}"
-client_key        "c:/chef/client.pem"
-validation_key    "c:/chef/validation.pem"
 
 file_cache_path   "c:/chef/cache"
 file_backup_path  "c:/chef/backup"

--- a/spec/functional/bootstrap_download_spec.rb
+++ b/spec/functional/bootstrap_download_spec.rb
@@ -118,10 +118,11 @@ describe 'Knife::Windows::Core msi download functionality for knife Windows winr
     clean_test_case
 
     winrm_bootstrapper = Chef::Knife::BootstrapWindowsWinrm.new([ "127.0.0.1" ])
-    winrm_bootstrapper.define_singleton_method(:client_builder){nil}
-
-    allow(winrm_bootstrapper.client_builder).to receive(:run)
-    allow(winrm_bootstrapper.client_builder).to receive(:client_path)
+    if chef_12?
+      winrm_bootstrapper.client_builder = instance_double("Chef::Knife::Bootstrap::ClientBuilder", :run => nil, :client_path => nil)
+      allow(winrm_bootstrapper.client_builder).to receive(:run)
+      allow(winrm_bootstrapper.client_builder).to receive(:client_path)
+    end
     allow(winrm_bootstrapper).to receive(:wait_for_remote_response)
     winrm_bootstrapper.config[:template_file] = @template_file_path
 

--- a/spec/functional/bootstrap_download_spec.rb
+++ b/spec/functional/bootstrap_download_spec.rb
@@ -91,6 +91,7 @@ describe 'Knife::Windows::Core msi download functionality for knife Windows winr
     it "downloads the chef-client MSI from the default location during winrm bootstrap" do
       run_download_scenario
     end
+
     context "when provided a custom msi_url to fetch from" do
       let(:mock_bootstrap_context) { Chef::Knife::Core::WindowsBootstrapContext.new(
         { :msi_url => "file:///C:/Windows/System32/xcopy.exe" }, nil, { :knife => {} }) }
@@ -98,6 +99,7 @@ describe 'Knife::Windows::Core msi download functionality for knife Windows winr
         run_download_scenario
       end
     end
+
   end
 
   def download_succeeded?
@@ -115,6 +117,8 @@ describe 'Knife::Windows::Core msi download functionality for knife Windows winr
     clean_test_case
 
     winrm_bootstrapper = Chef::Knife::BootstrapWindowsWinrm.new([ "127.0.0.1" ])
+    winrm_bootstrapper.define_singleton_method(:client_builder){nil}
+
     allow(winrm_bootstrapper.client_builder).to receive(:run)
     allow(winrm_bootstrapper.client_builder).to receive(:client_path)
     allow(winrm_bootstrapper).to receive(:wait_for_remote_response)

--- a/spec/functional/bootstrap_download_spec.rb
+++ b/spec/functional/bootstrap_download_spec.rb
@@ -115,6 +115,8 @@ describe 'Knife::Windows::Core msi download functionality for knife Windows winr
     clean_test_case
 
     winrm_bootstrapper = Chef::Knife::BootstrapWindowsWinrm.new([ "127.0.0.1" ])
+    allow(winrm_bootstrapper.client_builder).to receive(:run)
+    allow(winrm_bootstrapper.client_builder).to receive(:client_path)
     allow(winrm_bootstrapper).to receive(:wait_for_remote_response)
     winrm_bootstrapper.config[:template_file] = @template_file_path
 

--- a/spec/functional/bootstrap_download_spec.rb
+++ b/spec/functional/bootstrap_download_spec.rb
@@ -123,6 +123,11 @@ describe 'Knife::Windows::Core msi download functionality for knife Windows winr
       allow(winrm_bootstrapper.client_builder).to receive(:run)
       allow(winrm_bootstrapper.client_builder).to receive(:client_path)
     end
+
+    if chef_11?
+      allow(File).to receive(:exist?).with(File.expand_path(Chef::Config[:validation_key])).and_return(true)
+    end
+
     allow(winrm_bootstrapper).to receive(:wait_for_remote_response)
     winrm_bootstrapper.config[:template_file] = @template_file_path
 

--- a/spec/functional/bootstrap_download_spec.rb
+++ b/spec/functional/bootstrap_download_spec.rb
@@ -86,6 +86,7 @@ describe 'Knife::Windows::Core msi download functionality for knife Windows winr
       allow(Chef::Knife::Winrm).to receive(:new).and_return(mock_winrm)
 
       allow(Chef::Knife::Core::WindowsBootstrapContext).to receive(:new).and_return(mock_bootstrap_context)
+      Chef::Config[:knife] = {:winrm_transport => 'plaintext', :chef_node_name => 'foo.example.com', :winrm_authentication_protocol => 'negotiate'}
     end
 
     it "downloads the chef-client MSI from the default location during winrm bootstrap" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -54,6 +54,13 @@ def windows2012?
   is_win2k12
 end
 
+def chef_11?
+  Chef::VERSION.split('.').first.to_i == 11
+end
+
+def chef_12?
+  Chef::VERSION.split('.').first.to_i == 12
+end
 
 RSpec.configure do |config|
   config.filter_run_excluding :windows_only => true unless windows?

--- a/spec/unit/knife/bootstrap_template_spec.rb
+++ b/spec/unit/knife/bootstrap_template_spec.rb
@@ -28,10 +28,9 @@ describe Chef::Knife::BootstrapWindowsWinrm do
     knife.parse_options(options)
     # Avoid referencing a validation keyfile we won't find during #render_template
     template = IO.read(template_file).chomp
-    template_string = template.gsub(/^.*[Vv]alidation_key.*$/, '')
-    knife.render_template(template_string)
+    knife.render_template(template)
   end
-  
+
   before(:all) do
     @original_config = Chef::Config.hash_dup
     @original_knife_config = Chef::Config[:knife].dup
@@ -78,7 +77,7 @@ describe Chef::Knife::BootstrapWindowsWinrm do
     subject(:knife) { described_class.new }
 
     context "with explicitly provided msi_url" do
-      let(:options) { ["--msi_url", "file:///something.msi"] } 
+      let(:options) { ["--msi_url", "file:///something.msi"] }
 
       it "bootstrap batch file must fetch from provided url" do
         expect(rendered_template).to match(%r{.*REMOTE_SOURCE_MSI_URL=file:///something\.msi.*})

--- a/spec/unit/knife/bootstrap_windows_winrm_spec.rb
+++ b/spec/unit/knife/bootstrap_windows_winrm_spec.rb
@@ -85,8 +85,8 @@ describe Chef::Knife::BootstrapWindowsWinrm do
       allow(bootstrap).to receive(:create_bootstrap_bat_command).and_raise(SystemExit)
       expect(bootstrap).to receive(:wait_for_remote_response).with(2)
       allow(bootstrap).to receive(:validate_name_args!).and_return(nil)
-      expect(bootstrap.client_builder).to receive(:run)
-      expect(bootstrap.client_builder).to receive(:client_path).and_return("/")
+      allow(bootstrap.client_builder).to receive(:run)
+      allow(bootstrap.client_builder).to receive(:client_path).and_return("/")
       allow(bootstrap.ui).to receive(:info)
       bootstrap.config[:auth_timeout] = bootstrap.options[:auth_timeout][:default]
       expect { bootstrap.bootstrap }.to raise_error(SystemExit)

--- a/spec/unit/knife/bootstrap_windows_winrm_spec.rb
+++ b/spec/unit/knife/bootstrap_windows_winrm_spec.rb
@@ -139,10 +139,9 @@ describe Chef::Knife::BootstrapWindowsWinrm do
     if chef_11?
       before do
         allow(File).to receive(:exist?).with(File.expand_path(Chef::Config[:validation_key])).and_return(false)
-        Chef::Config[:knife] = {:winrm_transport => 'ssl', :chef_node_name => 'foo.example.com', :winrm_authentication_protocol => 'negotiate'}
       end
 
-      it 'raises an exception if validation_key is not present in chef11' do
+      it 'raises an exception if validation_key is not present in chef 11' do
         expect(bootstrap.ui).to receive(:error)
         expect { bootstrap.bootstrap }.to raise_error(SystemExit)
       end

--- a/spec/unit/knife/bootstrap_windows_winrm_spec.rb
+++ b/spec/unit/knife/bootstrap_windows_winrm_spec.rb
@@ -39,7 +39,8 @@ describe Chef::Knife::BootstrapWindowsWinrm do
   let(:session) { Chef::Knife::Winrm::WinrmSession.new({ :host => 'winrm.cloudapp.net', :port => '5986', :transport => :ssl }) }
 
   let(:initial_fail_count) { 4 }
-  it 'should retry if a 401 is received from WinRM' do
+
+    it 'should retry if a 401 is received from WinRM' do
     call_result_sequence = Array.new(initial_fail_count) {lambda {raise WinRM::WinRMHTTPTransportError.new('', '401')}}
     call_result_sequence.push(0)
     allow(bootstrap).to receive(:run_command).and_return(*call_result_sequence)
@@ -61,18 +62,6 @@ describe Chef::Knife::BootstrapWindowsWinrm do
     bootstrap.send(:wait_for_remote_response, 2)
   end
 
-  it 'should have a wait timeout of 2 minutes by default' do
-    allow(bootstrap).to receive(:run_command).and_raise(WinRM::WinRMHTTPTransportError.new('','500'))
-    allow(bootstrap).to receive(:create_bootstrap_bat_command).and_raise(SystemExit)
-    expect(bootstrap).to receive(:wait_for_remote_response).with(2)
-    allow(bootstrap).to receive(:validate_name_args!).and_return(nil)
-    allow(bootstrap.client_builder).to receive(:run)
-    allow(bootstrap.client_builder).to receive(:client_path).and_return("/")
-    allow(bootstrap.ui).to receive(:info)
-    bootstrap.config[:auth_timeout] = bootstrap.options[:auth_timeout][:default]
-    expect { bootstrap.bootstrap }.to raise_error(SystemExit)
-  end
-
   it 'should keep retrying at 10s intervals if the timeout in minutes has not elapsed' do
     call_result_sequence = Array.new(initial_fail_count) {lambda {raise WinRM::WinRMHTTPTransportError.new('', '500')}}
     call_result_sequence.push(0)
@@ -84,36 +73,102 @@ describe Chef::Knife::BootstrapWindowsWinrm do
     bootstrap.send(:wait_for_remote_response, 2)
   end
 
-  it "should exit bootstrap with non-zero status if the bootstrap fails" do
-    command_status = 1
+  context "when validation_key is not present" do
 
-    #Stub out calls to create the session and just get the exit codes back
-    winrm_mock = Chef::Knife::Winrm.new
-    allow(Chef::Knife::Winrm).to receive(:new).and_return(winrm_mock)
-    allow(winrm_mock).to receive(:run).and_raise(SystemExit.new(command_status))
-    #Skip over templating stuff and checking with the remote end
-    allow(bootstrap.client_builder).to receive(:run)
-    allow(bootstrap.client_builder).to receive(:client_path).and_return("/")
-    allow(bootstrap).to receive(:create_bootstrap_bat_command)
-    allow(bootstrap).to receive(:wait_for_remote_response)
-    allow(bootstrap.ui).to receive(:info)
+    before do
+      allow(File).to receive(:exist?).with(File.expand_path(Chef::Config[:validation_key])).and_return(false)
+      bootstrap.define_singleton_method(:client_builder){nil}
+    end
 
-    expect { bootstrap.run_with_pretty_exceptions }.to raise_error(SystemExit) { |e| expect(e.status).to eq(command_status) }
+    it 'should have a wait timeout of 2 minutes by default' do
+      allow(bootstrap).to receive(:run_command).and_raise(WinRM::WinRMHTTPTransportError.new('','500'))
+      allow(bootstrap).to receive(:create_bootstrap_bat_command).and_raise(SystemExit)
+      expect(bootstrap).to receive(:wait_for_remote_response).with(2)
+      allow(bootstrap).to receive(:validate_name_args!).and_return(nil)
+      expect(bootstrap.client_builder).to receive(:run)
+      expect(bootstrap.client_builder).to receive(:client_path).and_return("/")
+      allow(bootstrap.ui).to receive(:info)
+      bootstrap.config[:auth_timeout] = bootstrap.options[:auth_timeout][:default]
+      expect { bootstrap.bootstrap }.to raise_error(SystemExit)
+    end
+
+    it "should exit bootstrap with non-zero status if the bootstrap fails" do
+      command_status = 1
+
+      #Stub out calls to create the session and just get the exit codes back
+      winrm_mock = Chef::Knife::Winrm.new
+      allow(Chef::Knife::Winrm).to receive(:new).and_return(winrm_mock)
+      allow(winrm_mock).to receive(:run).and_raise(SystemExit.new(command_status))
+      #Skip over templating stuff and checking with the remote end
+      allow(bootstrap.client_builder).to receive(:run)
+      allow(bootstrap.client_builder).to receive(:client_path).and_return("/")
+      allow(bootstrap).to receive(:create_bootstrap_bat_command)
+      allow(bootstrap).to receive(:wait_for_remote_response)
+      allow(bootstrap.ui).to receive(:info)
+
+      expect { bootstrap.run_with_pretty_exceptions }.to raise_error(SystemExit) { |e| expect(e.status).to eq(command_status) }
+    end
+
+    it 'should stop retrying if more than 2 minutes has elapsed' do
+      times = [ Time.new(2014, 4, 1, 22, 25), Time.new(2014, 4, 1, 22, 51), Time.new(2014, 4, 1, 22, 28) ]
+      allow(Time).to receive(:now).and_return(*times)
+      allow(bootstrap.client_builder).to receive(:run)
+      allow(bootstrap.client_builder).to receive(:client_path).and_return("/")
+      run_command_result = lambda {raise WinRM::WinRMHTTPTransportError, '401'}
+      allow(bootstrap).to receive(:validate_name_args!).and_return(nil)
+      allow(bootstrap).to receive(:run_command).and_return(run_command_result)
+      allow(bootstrap).to receive(:print)
+      allow(bootstrap.ui).to receive(:info)
+      allow(bootstrap.ui).to receive(:error)
+      expect(bootstrap).to receive(:run_command).exactly(1).times
+      bootstrap.config[:auth_timeout] = bootstrap.options[:auth_timeout][:default]
+      expect { bootstrap.bootstrap }.to raise_error RuntimeError
+    end
   end
 
-  it 'should stop retrying if more than 2 minutes has elapsed' do
-    times = [ Time.new(2014, 4, 1, 22, 25), Time.new(2014, 4, 1, 22, 51), Time.new(2014, 4, 1, 22, 28) ]
-    allow(Time).to receive(:now).and_return(*times)
-    allow(bootstrap.client_builder).to receive(:run)
-    allow(bootstrap.client_builder).to receive(:client_path).and_return("/")
-    run_command_result = lambda {raise WinRM::WinRMHTTPTransportError, '401'}
-    allow(bootstrap).to receive(:validate_name_args!).and_return(nil)
-    allow(bootstrap).to receive(:run_command).and_return(run_command_result)
-    allow(bootstrap).to receive(:print)
-    allow(bootstrap.ui).to receive(:info)
-    allow(bootstrap.ui).to receive(:error)
-    expect(bootstrap).to receive(:run_command).exactly(1).times
-    bootstrap.config[:auth_timeout] = bootstrap.options[:auth_timeout][:default]
-    expect { bootstrap.bootstrap }.to raise_error RuntimeError
+  context "when validation_key is present" do
+    before do
+      allow(File).to receive(:exist?).with(File.expand_path(Chef::Config[:validation_key])).and_return(true)
+    end
+
+    it 'should have a wait timeout of 2 minutes by default' do
+      allow(bootstrap).to receive(:run_command).and_raise(WinRM::WinRMHTTPTransportError.new('','500'))
+      allow(bootstrap).to receive(:create_bootstrap_bat_command).and_raise(SystemExit)
+      expect(bootstrap).to receive(:wait_for_remote_response).with(2)
+      allow(bootstrap).to receive(:validate_name_args!).and_return(nil)
+      allow(bootstrap.ui).to receive(:info)
+      bootstrap.config[:auth_timeout] = bootstrap.options[:auth_timeout][:default]
+      expect { bootstrap.bootstrap }.to raise_error(SystemExit)
+    end
+
+    it "should exit bootstrap with non-zero status if the bootstrap fails" do
+      command_status = 1
+
+      #Stub out calls to create the session and just get the exit codes back
+      winrm_mock = Chef::Knife::Winrm.new
+      allow(Chef::Knife::Winrm).to receive(:new).and_return(winrm_mock)
+      allow(winrm_mock).to receive(:run).and_raise(SystemExit.new(command_status))
+      #Skip over templating stuff and checking with the remote end
+      allow(bootstrap).to receive(:create_bootstrap_bat_command)
+      allow(bootstrap).to receive(:wait_for_remote_response)
+      allow(bootstrap.ui).to receive(:info)
+
+      expect { bootstrap.run_with_pretty_exceptions }.to raise_error(SystemExit) { |e| expect(e.status).to eq(command_status) }
+    end
+
+    it 'should stop retrying if more than 2 minutes has elapsed' do
+      times = [ Time.new(2014, 4, 1, 22, 25), Time.new(2014, 4, 1, 22, 51), Time.new(2014, 4, 1, 22, 28) ]
+      allow(Time).to receive(:now).and_return(*times)
+      run_command_result = lambda {raise WinRM::WinRMHTTPTransportError, '401'}
+      allow(bootstrap).to receive(:validate_name_args!).and_return(nil)
+      allow(bootstrap).to receive(:run_command).and_return(run_command_result)
+      allow(bootstrap).to receive(:print)
+      allow(bootstrap.ui).to receive(:info)
+      allow(bootstrap.ui).to receive(:error)
+      expect(bootstrap).to receive(:run_command).exactly(1).times
+      bootstrap.config[:auth_timeout] = bootstrap.options[:auth_timeout][:default]
+      expect { bootstrap.bootstrap }.to raise_error RuntimeError
+    end
   end
+
 end

--- a/spec/unit/knife/bootstrap_windows_winrm_spec.rb
+++ b/spec/unit/knife/bootstrap_windows_winrm_spec.rb
@@ -66,6 +66,8 @@ describe Chef::Knife::BootstrapWindowsWinrm do
     allow(bootstrap).to receive(:create_bootstrap_bat_command).and_raise(SystemExit)
     expect(bootstrap).to receive(:wait_for_remote_response).with(2)
     allow(bootstrap).to receive(:validate_name_args!).and_return(nil)
+    allow(bootstrap.client_builder).to receive(:run)
+    allow(bootstrap.client_builder).to receive(:client_path).and_return("/")
     allow(bootstrap.ui).to receive(:info)
     bootstrap.config[:auth_timeout] = bootstrap.options[:auth_timeout][:default]
     expect { bootstrap.bootstrap }.to raise_error(SystemExit)
@@ -87,9 +89,11 @@ describe Chef::Knife::BootstrapWindowsWinrm do
 
     #Stub out calls to create the session and just get the exit codes back
     winrm_mock = Chef::Knife::Winrm.new
-    allow(Chef::Knife::Winrm).to receive(:new).and_return(winrm_mock)    
+    allow(Chef::Knife::Winrm).to receive(:new).and_return(winrm_mock)
     allow(winrm_mock).to receive(:run).and_raise(SystemExit.new(command_status))
     #Skip over templating stuff and checking with the remote end
+    allow(bootstrap.client_builder).to receive(:run)
+    allow(bootstrap.client_builder).to receive(:client_path).and_return("/")
     allow(bootstrap).to receive(:create_bootstrap_bat_command)
     allow(bootstrap).to receive(:wait_for_remote_response)
     allow(bootstrap.ui).to receive(:info)
@@ -97,10 +101,11 @@ describe Chef::Knife::BootstrapWindowsWinrm do
     expect { bootstrap.run_with_pretty_exceptions }.to raise_error(SystemExit) { |e| expect(e.status).to eq(command_status) }
   end
 
-
   it 'should stop retrying if more than 2 minutes has elapsed' do
     times = [ Time.new(2014, 4, 1, 22, 25), Time.new(2014, 4, 1, 22, 51), Time.new(2014, 4, 1, 22, 28) ]
     allow(Time).to receive(:now).and_return(*times)
+    allow(bootstrap.client_builder).to receive(:run)
+    allow(bootstrap.client_builder).to receive(:client_path).and_return("/")
     run_command_result = lambda {raise WinRM::WinRMHTTPTransportError, '401'}
     allow(bootstrap).to receive(:validate_name_args!).and_return(nil)
     allow(bootstrap).to receive(:run_command).and_return(run_command_result)


### PR DESCRIPTION
1) This change needs chef >= 12.2
2) --node-name option needs to be passed while bootstrap
3) Specs pending