### PR TITLE
make winrm-s dep more strict on knife-windows 0.8.x

### DIFF
--- a/knife-windows.gemspec
+++ b/knife-windows.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.description = s.summary
 
   s.required_ruby_version	= ">= 1.9.1"
-  s.add_dependency "winrm-s", "~> 0.2"
+  s.add_dependency "winrm-s", "~> 0.2.0"
   s.add_dependency "em-winrm", "~> 0.6"
 
   s.add_development_dependency 'pry'

--- a/lib/knife-windows/version.rb
+++ b/lib/knife-windows/version.rb
@@ -1,6 +1,6 @@
 module Knife
   module Windows
-    VERSION = "0.8.4"
+    VERSION = "0.8.5.rc.0"
     MAJOR, MINOR, TINY = VERSION.split('.')
   end
 end


### PR DESCRIPTION
Previously we pinned to ~> 0.2, which would have pulled in winrm-s 0.3.0.
winrm-s 0.3.0 depends on winrm 1.3.0, which has some major changes.

Since knife-windows 1.0.0 is a major change, including the removal of em-winrm,
I want to stabilize the knife-windows 0.8.x branch.