### PR TITLE
Update Travis/Appveyor to test Chef 11 + Chef 12

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.gem
 .bundle
 Gemfile.lock
+ci.gemfile.lock
 pkg/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,20 @@
-rvm:
-  - 2.0.0
-  - 2.1.5
-  - 2.2.0
+language: ruby
 
-script: bundle exec rake spec
+rvm:
+  - 1.9.3
+  - 2.0.0
+
+gemfile: ci.gemfile
+
+env:
+  - CHEF_VERSION="master"
+  - CHEF_VERSION="~> 12.0"
+  - CHEF_VERSION="< 12"
+
+matrix:
+  exclude:
+  - rvm: 1.9.3
+    env: CHEF_VERSION="master"
+  - rvm: 1.9.3
+    env: CHEF_VERSION="~> 12.0"
+

--- a/Gemfile
+++ b/Gemfile
@@ -3,13 +3,8 @@ source "https://rubygems.org"
 # Specify your gem's dependencies in knife-windows.gemspec
 gemspec
 
-# TODO: Remove this line when a new version of `winrm-s` is released which contains:
-#
-#   https://github.com/chef/winrm-s/commit/d9a85d7c93ef4c24faaea760cdc58a3532d599e9
-#
-gem 'winrm-s', github: 'chef/winrm-s'
-
 group :test do
+  gem "chef"
   gem "rspec", '~> 3.0'
   gem "ruby-wmi"
   gem "httpclient"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,9 +5,20 @@ platform:
   - x64
 
 environment:
+  bundle_gemfile: ci.gemfile
+
   matrix:
     - ruby_version: "193"
+      chef_version: "< 12"
+
     - ruby_version: "200"
+      chef_version: "< 12"
+
+    - ruby_version: "200"
+      chef_version: "~> 12.0"
+
+    - ruby_version: "200"
+      chef_version: "master"
 
 clone_folder: c:\projects\knife-windows
 clone_depth: 1

--- a/ci.gemfile
+++ b/ci.gemfile
@@ -1,0 +1,15 @@
+source "https://rubygems.org"
+
+# Specify your gem's dependencies in knife-windows.gemspec
+gemspec
+
+if ENV['CHEF_VERSION'] == 'master'
+  gem 'chef', github: 'chef/chef'
+else
+  gem 'chef', ENV['CHEF_VERSION']
+end
+
+gem "rspec", '~> 3.0'
+gem "ruby-wmi"
+gem "httpclient"
+gem 'rake'

--- a/knife-windows.gemspec
+++ b/knife-windows.gemspec
@@ -18,9 +18,7 @@ Gem::Specification.new do |s|
   s.add_dependency "winrm-s", "~> 0.3.0.dev.0"
   s.add_dependency "nokogiri"
 
-
   s.add_development_dependency 'pry'
-  s.add_development_dependency 'chef', '< 12'
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")


### PR DESCRIPTION
We're adding code to knife-windows to support features like validatorless bootstrap (#224) that only works on Chef 12, so we need to be able to test with Chef 12 so we can ensure we raise errors or actually work as appropriate.