### PR TITLE
Adding --hint option to bootstrap 

### DIFF
--- a/lib/chef/knife/bootstrap_windows_base.rb
+++ b/lib/chef/knife/bootstrap_windows_base.rb
@@ -80,6 +80,15 @@ class Chef
             :proc => lambda { |o| o.split(",") },
             :default => []
 
+          option :hint,
+            :long => "--hint HINT_NAME[=HINT_FILE]",
+            :description => "Specify Ohai Hint to be set on the bootstrap target.  Use multiple --hint options to specify multiple hints.",
+            :proc => Proc.new { |h|
+              Chef::Config[:knife][:hints] ||= Hash.new
+              name, path = h.split("=")
+              Chef::Config[:knife][:hints][name] = path ? Chef::JSONCompat.parse(::File.read(path)) : Hash.new
+            }
+        
           option :first_boot_attributes,
             :short => "-j JSON_ATTRIBS",
             :long => "--json-attributes",


### PR DESCRIPTION
Adding --hint option to 'knife bootstrap windows" command  in order work
with windows cloud VM instances (like ec2) and to get cloud specific
ohai attributes (like public ipaddress) and save those to node object on
chef.