### PR TITLE
Validation key can be false

### DIFF
--- a/lib/chef/knife/core/windows_bootstrap_context.rb
+++ b/lib/chef/knife/core/windows_bootstrap_context.rb
@@ -49,7 +49,11 @@ class Chef
         end
 
         def validation_key
-          escape_and_echo(super)
+          if super
+            escape_and_echo(super)
+          else
+            false
+          end
         end
 
         def secret

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -54,9 +54,15 @@ def windows2012?
   is_win2k12
 end
 
+def gt_chef12?
+  Gem::Version.new(Chef::VERSION) > Gem::Version.new("12.0.0")
+end
+
+
 
 RSpec.configure do |config|
   config.filter_run_excluding :windows_only => true unless windows?
   config.filter_run_excluding :windows_2012_only => true unless windows2012?
+  config.filter_run_excluding :gt_chef12_only => true unless gt_chef12?
 end
 

--- a/spec/unit/knife/core/windows_bootstrap_context_spec.rb
+++ b/spec/unit/knife/core/windows_bootstrap_context_spec.rb
@@ -25,6 +25,18 @@ describe Chef::Knife::Core::WindowsBootstrapContext do
      allow(Chef::Knife::Core::WindowsBootstrapContext).to receive(:new).and_return(mock_bootstrap_context)
    end
 
+  describe "validation_key", :gt_chef12_only do
+    before do
+      mock_bootstrap_context.instance_variable_set(:@config, Mash.new(:validation_key => "C:\\chef\\key.pem"))
+    end
+
+    it "should return false if validation_key does not exist" do
+      allow(::File).to receive(:expand_path)
+      allow(::File).to receive(:exist?).and_return(false)
+      expect(mock_bootstrap_context.validation_key).to eq(false)
+    end
+  end
+
   describe "latest_current_windows_chef_version_query" do
     it "returns the major version of the current version of Chef" do
       stub_const("Chef::VERSION", '11.1.2')


### PR DESCRIPTION
This fixes #227.

In `boostrap_context.rb`, validation_key is defined as

```ruby
def validation_key
  if File.exist?(File.expand_path(@chef_config[:validation_key]))
    IO.read(File.expand_path(@chef_config[:validation_key]))
  else
    false
  end
end
```