### PR TITLE
Disable caching in appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,10 +26,6 @@ branches:
   only:
     - master
 
-cache:
-  - C:\Ruby200\lib\ruby\gems\2.0.0
-  - C:\Ruby200\bin
-
 install:
   - winrm quickconfig -q
   - SET PATH=C:\Ruby%ruby_version%\bin;%PATH%


### PR DESCRIPTION
This is breaking bundler when it has to do a git checkout