### PR TITLE
Fix null validation_key error

### DIFF
--- a/spec/functional/bootstrap_download_spec.rb
+++ b/spec/functional/bootstrap_download_spec.rb
@@ -118,9 +118,9 @@ describe 'Knife::Windows::Core msi download functionality for knife Windows winr
 
     winrm_bootstrapper = Chef::Knife::BootstrapWindowsWinrm.new([ "127.0.0.1" ])
 
-    if chef_12?
+    if chef_gte_12?
       winrm_bootstrapper.client_builder = instance_double("Chef::Knife::Bootstrap::ClientBuilder", :run => nil, :client_path => nil)
-    elsif chef_11?
+    elsif chef_lt_12?
       allow(File).to receive(:exist?).with(File.expand_path(Chef::Config[:validation_key])).and_return(true)
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -62,10 +62,15 @@ def chef_12?
   Chef::VERSION.split('.').first.to_i == 12
 end
 
+def gt_chef12?
+  Gem::Version.new(Chef::VERSION) > Gem::Version.new("12.0.0")
+end
+
 RSpec.configure do |config|
   config.filter_run_excluding :windows_only => true unless windows?
   config.filter_run_excluding :windows_2012_only => true unless windows2012?
   config.filter_run_excluding :chef_11_only unless chef_11?
   config.filter_run_excluding :chef_12_only unless chef_12?
+  config.filter_run_excluding :gt_chef12_only => true unless gt_chef12?
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -54,23 +54,18 @@ def windows2012?
   is_win2k12
 end
 
-def chef_11?
-  Chef::VERSION.split('.').first.to_i == 11
+def chef_gte_12?
+  Chef::VERSION.split('.').first.to_i >= 12
 end
 
-def chef_12?
-  Chef::VERSION.split('.').first.to_i == 12
-end
-
-def gt_chef12?
-  Gem::Version.new(Chef::VERSION) > Gem::Version.new("12.0.0")
+def chef_lt_12?
+  Chef::VERSION.split('.').first.to_i < 12
 end
 
 RSpec.configure do |config|
   config.filter_run_excluding :windows_only => true unless windows?
   config.filter_run_excluding :windows_2012_only => true unless windows2012?
-  config.filter_run_excluding :chef_11_only unless chef_11?
-  config.filter_run_excluding :chef_12_only unless chef_12?
-  config.filter_run_excluding :gt_chef12_only => true unless gt_chef12?
+  config.filter_run_excluding :chef_gte_12_only => true unless chef_gte_12?
+  config.filter_run_excluding :chef_lt_12_only => true unless chef_lt_12?
 end
 

--- a/spec/unit/knife/bootstrap_windows_winrm_spec.rb
+++ b/spec/unit/knife/bootstrap_windows_winrm_spec.rb
@@ -114,7 +114,7 @@ describe Chef::Knife::BootstrapWindowsWinrm do
   end
 
   context "when validation_key is not present" do
-    context "using chef 11", :chef_11_only do
+    context "using chef 11", :chef_lt_12_only do
       before do
         allow(File).to receive(:exist?).with(File.expand_path(Chef::Config[:validation_key])).and_return(false)
       end
@@ -125,7 +125,7 @@ describe Chef::Knife::BootstrapWindowsWinrm do
       end
     end
 
-    context "using chef 12", :chef_12_only do
+    context "using chef 12", :chef_gte_12_only do
       before do
         allow(File).to receive(:exist?).with(File.expand_path(Chef::Config[:validation_key])).and_return(false)
         bootstrap.client_builder = instance_double("Chef::Knife::Bootstrap::ClientBuilder", :run => nil, :client_path => nil)

--- a/spec/unit/knife/core/windows_bootstrap_context_spec.rb
+++ b/spec/unit/knife/core/windows_bootstrap_context_spec.rb
@@ -25,7 +25,7 @@ describe Chef::Knife::Core::WindowsBootstrapContext do
      allow(Chef::Knife::Core::WindowsBootstrapContext).to receive(:new).and_return(mock_bootstrap_context)
    end
 
-  describe "validation_key", :gt_chef12_only do
+  describe "validation_key", :chef_gte_12_only do
     before do
       mock_bootstrap_context.instance_variable_set(:@config, Mash.new(:validation_key => "C:\\chef\\key.pem"))
     end

--- a/spec/unit/knife/core/windows_bootstrap_context_spec.rb
+++ b/spec/unit/knife/core/windows_bootstrap_context_spec.rb
@@ -25,6 +25,18 @@ describe Chef::Knife::Core::WindowsBootstrapContext do
      allow(Chef::Knife::Core::WindowsBootstrapContext).to receive(:new).and_return(mock_bootstrap_context)
    end
 
+  describe "validation_key", :gt_chef12_only do
+    before do
+      mock_bootstrap_context.instance_variable_set(:@config, Mash.new(:validation_key => "C:\\chef\\key.pem"))
+    end
+
+    it "should return false if validation_key does not exist" do
+      allow(::File).to receive(:expand_path)
+      allow(::File).to receive(:exist?).and_return(false)
+      expect(mock_bootstrap_context.validation_key).to eq(false)
+    end
+  end
+
   describe "latest_current_windows_chef_version_query" do
     it "returns the major version of the current version of Chef" do
       stub_const("Chef::VERSION", '11.1.2')


### PR DESCRIPTION
Replaces #235.

* Rebased against master with the new validatorless bootstrap support
* Updated the platform helpers in the spec tests to match Chef's bikeshed
