### PR TITLE
Change kerberos keytab short option to -T to resolve conflict

### DIFF
--- a/lib/chef/knife/winrm_base.rb
+++ b/lib/chef/knife/winrm_base.rb
@@ -72,7 +72,7 @@ class Chef
             :description => "The SSH identity file used for authentication"
 
           option :kerberos_keytab_file,
-            :short => "-i KEYTAB_FILE",
+            :short => "-T KEYTAB_FILE",
             :long => "--keytab-file KEYTAB_FILE",
             :description => "The Kerberos keytab file used for authentication",
             :proc => Proc.new { |keytab| Chef::Config[:knife][:kerberos_keytab_file] = keytab }


### PR DESCRIPTION
It currently uses -i, which the identity file also uses. -T looks available
per the `knife windows bootstrap winrm --help` output.

Fixes #110 

@chef/client-windows, @jamescott  