### PR TITLE
Fixed winrm bootstrap failures don't fail until they timeout 

### DIFF
--- a/lib/chef/knife/bootstrap_windows_winrm.rb
+++ b/lib/chef/knife/bootstrap_windows_winrm.rb
@@ -89,18 +89,14 @@ class Chef
           raise RuntimeError, 'Command execution failed.' if status != 0
           ui.info(ui.color("Remote node responded after #{elapsed_time_in_minutes(wait_start_time)} minutes.", :magenta))
           return
-        rescue
+        rescue Errno::ECONNREFUSED => e
+          ui.error("Connection refused connecting to #{locate_config_value(:server_name)}:#{locate_config_value(:winrm_port)}.")
+          raise
+        rescue Exception => e
           retries_left -= 1
-          # $! will contain the current exception object
-          if $!.class.equal?(Errno::ECONNREFUSED)
-            ui.error("RuntimeError: No response received from remote node.")
-            ui.info("Hint: Please check remote server's winrm configuration i.e '$ winrm/config/service' AllowUnencrypted flag")
-            raise
-          end
-
           if retries_left <= 0 || (elapsed_time_in_minutes(wait_start_time) > wait_max_minutes)
             ui.error("No response received from remote node after #{elapsed_time_in_minutes(wait_start_time)} minutes, giving up.")
-            ui.info("Hint: Please check remote server's winrm configuration i.e '$ winrm/config/service' AllowUnencrypted flag")
+            ui.error("Exception: #{e.message}")
             raise
           end
           print '.'

--- a/lib/chef/knife/bootstrap_windows_winrm.rb
+++ b/lib/chef/knife/bootstrap_windows_winrm.rb
@@ -91,8 +91,16 @@ class Chef
           return
         rescue
           retries_left -= 1
+          # $! will contain the current exception object
+          if $!.class.equal?(Errno::ECONNREFUSED)
+            ui.error("RuntimeError: No response received from remote node.")
+            ui.info("Hint: Please check remote server's winrm configuration i.e '$ winrm/config/service' AllowUnencrypted flag")
+            raise
+          end
+
           if retries_left <= 0 || (elapsed_time_in_minutes(wait_start_time) > wait_max_minutes)
             ui.error("No response received from remote node after #{elapsed_time_in_minutes(wait_start_time)} minutes, giving up.")
+            ui.info("Hint: Please check remote server's winrm configuration i.e '$ winrm/config/service' AllowUnencrypted flag")
             raise
           end
           print '.'

--- a/spec/unit/knife/bootstrap_windows_winrm_spec.rb
+++ b/spec/unit/knife/bootstrap_windows_winrm_spec.rb
@@ -85,7 +85,7 @@ describe Chef::Knife::BootstrapWindowsWinrm do
   end
 
   it 'should not a wait for timeout on Errno::ECONNREFUSED' do
-    allow(bootstrap).to receive(:run_command).and_raise(Errno::ECONNREFUSED.new('','500'))
+    allow(bootstrap).to receive(:run_command).and_raise(Errno::ECONNREFUSED.new)
     allow(bootstrap.ui).to receive(:info)
     bootstrap.config[:auth_timeout] = bootstrap.options[:auth_timeout][:default]
     expect(bootstrap.ui).to receive(:error).with("Connection refused connecting to localhost:5985.")

--- a/spec/unit/knife/bootstrap_windows_winrm_spec.rb
+++ b/spec/unit/knife/bootstrap_windows_winrm_spec.rb
@@ -84,6 +84,17 @@ describe Chef::Knife::BootstrapWindowsWinrm do
     expect { bootstrap.bootstrap }.to raise_error(SystemExit)
   end
 
+  it 'should not a wait for timeout on Errno::ECONNREFUSED' do
+    allow(bootstrap).to receive(:run_command).and_raise(Errno::ECONNREFUSED.new('','500'))
+    allow(bootstrap.ui).to receive(:info)
+    bootstrap.config[:auth_timeout] = bootstrap.options[:auth_timeout][:default]
+    expect(bootstrap.ui).to receive(:error).with("Connection refused connecting to localhost:5985.")
+
+    # wait_for_remote_response is protected method, So define singleton test method to call it.
+    bootstrap.define_singleton_method(:test_wait_for_remote_response){wait_for_remote_response(bootstrap.options[:auth_timeout][:default])}
+    expect { bootstrap.test_wait_for_remote_response }.to raise_error(Errno::ECONNREFUSED)
+  end
+
   it "should exit bootstrap with non-zero status if the bootstrap fails" do
     command_status = 1
 


### PR DESCRIPTION
Issue ref- https://github.com/chef/knife-windows/issues/244 