### PR TITLE
fixes #280 preventing unencrypted negotiate auth on non windows

### DIFF
--- a/lib/chef/knife/bootstrap_windows_winrm.rb
+++ b/lib/chef/knife/bootstrap_windows_winrm.rb
@@ -39,9 +39,7 @@ class Chef
 
       banner 'knife bootstrap windows winrm FQDN (options)'
 
-      def run
-        validate_options!
-
+      def run       
         if (Chef::Config[:validation_key] && !File.exist?(File.expand_path(Chef::Config[:validation_key])))
           if !negotiate_auth? && !(locate_config_value(:winrm_transport) == 'ssl')
             ui.error('Validatorless bootstrap over unsecure winrm channels could expose your key to network sniffing')
@@ -49,29 +47,17 @@ class Chef
           end
         end
 
+        validate_options
+        resolve_session_options
+        @session_opts[:host] = server_name
+        @session = Chef::Knife::WinrmSession.new(@session_opts)
+
         bootstrap
       end
 
       def run_command(command = '')
-        winrm = Chef::Knife::Winrm.new
-        winrm.name_args = [ server_name, command ]
-        winrm.config[:winrm_user] = locate_config_value(:winrm_user)
-        winrm.config[:winrm_password] = locate_config_value(:winrm_password)
-        winrm.config[:winrm_transport] = locate_config_value(:winrm_transport)
-        winrm.config[:winrm_ssl_verify_mode] = locate_config_value(:winrm_ssl_verify_mode)
-        winrm.config[:kerberos_keytab_file] = locate_config_value(:kerberos_keytab_file) if locate_config_value(:kerberos_keytab_file)
-        winrm.config[:kerberos_realm] = locate_config_value(:kerberos_realm) if locate_config_value(:kerberos_realm)
-        winrm.config[:kerberos_service] = locate_config_value(:kerberos_service) if locate_config_value(:kerberos_service)
-        winrm.config[:ca_trust_file] = locate_config_value(:ca_trust_file) if locate_config_value(:ca_trust_file)
-        winrm.config[:manual] = true
-        winrm.config[:winrm_port] = locate_config_value(:winrm_port)
-        winrm.config[:suppress_auth_failure] = true
-
-        #If you turn off the return flag, then winrm.run won't atually check and
-        #return the error
-        #codes.  Otherwise, it ignores the return value of the server call.
-        winrm.config[:returns] = "0"
-        winrm.run
+        @session.relay_command(command)
+        return @session.exit_code
       end
 
       protected

--- a/lib/chef/knife/winrm_knife_base.rb
+++ b/lib/chef/knife/winrm_knife_base.rb
@@ -122,7 +122,7 @@ class Chef
           end
 
           def resolve_winrm_kerberos_options
-            if config.keys.any? {|k| k.to_s =~ /kerberos/ }
+            if config.any? {|k,v| k.to_s =~ /kerberos/ && !v.nil? }
               @session_opts[:transport] = :kerberos
               @session_opts[:keytab] = locate_config_value(:kerberos_keytab_file) if locate_config_value(:kerberos_keytab_file)
               @session_opts[:realm] = locate_config_value(:kerberos_realm) if locate_config_value(:kerberos_realm)

--- a/lib/chef/knife/winrm_knife_base.rb
+++ b/lib/chef/knife/winrm_knife_base.rb
@@ -34,17 +34,21 @@ class Chef
 
           #Overrides Chef::Knife#configure_session, as that code is tied to the SSH implementation
           #Tracked by Issue # 3042 / https://github.com/chef/chef/issues/3042
-          def validate_options!
+          def validate_options
             if negotiate_auth? && !Chef::Platform.windows? && !(locate_config_value(:winrm_transport) == 'ssl')
-              ui.warn "\n Using '--winrm-authentication-protocol negotiate' with '--winrm-transport plaintext' is only
-              supported when this tool is invoked from a Windows system. Switch to either '--winrm-transport ssl' or
-              '--winrm-authentication-protocol basic'.".strip
-              exit 1
+              ui.warn <<-eos.gsub /^\s+/, ""
+                You are using '--winrm-authentication-protocol negotiate' with 
+                '--winrm-transport plaintext' on a non-Windows system which results in
+                unencrypted traffic. To avoid this warning and secure communication,
+                use '--winrm-transport ssl' instead of the plaintext transport,
+                or execute this command from a Windows system which enables encrypted
+                communication over plaintext with the negotiate authentication protocol.
+              eos
             end
           end
 
           def configure_session
-            validate_options!
+            validate_options
             resolve_session_options
             resolve_target_nodes
             session_from_list
@@ -64,6 +68,7 @@ class Chef
                      end
                      r
                    end
+             
              if @list.length == 0
               if @action_nodes.length == 0
                 ui.fatal("No nodes returned from search!")

--- a/spec/unit/knife/bootstrap_windows_winrm_spec.rb
+++ b/spec/unit/knife/bootstrap_windows_winrm_spec.rb
@@ -189,21 +189,6 @@ describe Chef::Knife::BootstrapWindowsWinrm do
     expect { bootstrap.test_wait_for_remote_response }.to raise_error(Errno::ECONNREFUSED)
   end
 
-  it "should exit bootstrap with non-zero status if the bootstrap fails" do
-    command_status = 1
-
-    #Stub out calls to create the session and just get the exit codes back
-    winrm_mock = Chef::Knife::Winrm.new
-    allow(Chef::Knife::Winrm).to receive(:new).and_return(winrm_mock)
-    allow(winrm_mock).to receive(:run).and_raise(SystemExit.new(command_status))
-    #Skip over templating stuff and checking with the remote end
-    allow(bootstrap).to receive(:create_bootstrap_bat_command)
-    allow(bootstrap).to receive(:wait_for_remote_response)
-    allow(bootstrap.ui).to receive(:info)
-
-    expect { bootstrap.run_with_pretty_exceptions }.to raise_error(SystemExit) { |e| expect(e.status).to eq(command_status) }
-  end
-
   it 'should stop retrying if more than 2 minutes has elapsed' do
     times = [ Time.new(2014, 4, 1, 22, 25), Time.new(2014, 4, 1, 22, 51), Time.new(2014, 4, 1, 22, 28) ]
     allow(Time).to receive(:now).and_return(*times)

--- a/spec/unit/knife/winrm_spec.rb
+++ b/spec/unit/knife/winrm_spec.rb
@@ -385,13 +385,13 @@ describe Chef::Knife::Winrm do
             @winrm.run
           end
 
-          it "prints a warning and exits on linux for unencrypted negotiate authentication" do
+          it "prints a warning on linux for unencrypted negotiate authentication" do
             @winrm.config[:winrm_authentication_protocol] = "negotiate"
             @winrm.config[:winrm_transport] = "plaintext"
             allow(Chef::Platform).to receive(:windows?).and_return(false)
             expect(@winrm).to_not receive(:require).with('winrm-s')
             expect(@winrm.ui).to receive(:warn).once
-            expect { @winrm.run }.to raise_error(SystemExit)
+            expect { @winrm.run }.to_not raise_error(SystemExit)
           end
         end
       end


### PR DESCRIPTION
this prevents unencrypted negotiate auth on non windows from failing and improves the warning message. To prevent this warning from being displayed on every winrm command during bootstrap, the winrm bootstrap command is refactored to validate this authentication method on its own and then call a single winrm session for all winrm calls instead of calling run on a new winrm knife instance for each call that would perform the validation each time.
