### PR TITLE
prefix local usernames with dot domain notation when using negotiate

### DIFF
--- a/lib/chef/knife/bootstrap_windows_winrm.rb
+++ b/lib/chef/knife/bootstrap_windows_winrm.rb
@@ -47,8 +47,9 @@ class Chef
           end
         end
 
-        validate_options
+        validate_options!
         resolve_session_options
+        load_windows_specific_gems if @session_opts[:transport] == :sspinegotiate
         @session_opts[:host] = server_name
         @session = Chef::Knife::WinrmSession.new(@session_opts)
 


### PR DESCRIPTION
Under some circumstances, negotiate authentication will fail using a local account if the "local domain" is not specified. Users may likely neglect to prefix a local username with the machine name or IP address and its confusing why access is being denied. This PR detects if an explicit domain is not being sent when using negotiate and if not, uses the short form `.\{user}` username.