### PR TITLE
use configured proxy settings for all winrm sessions

### DIFF
--- a/lib/chef/knife/winrm_session.rb
+++ b/lib/chef/knife/winrm_session.rb
@@ -16,6 +16,7 @@
 # limitations under the License.
 #
 
+require 'chef/application'
 require 'winrm'
 
 class Chef
@@ -24,6 +25,7 @@ class Chef
       attr_reader :host, :endpoint, :port, :output, :error, :exit_code
 
       def initialize(options)
+        Chef::Application.new.configure_proxy_environment_variables
         @host = options[:host]
         @port = options[:port]
         url = "#{options[:host]}:#{options[:port]}/wsman"

--- a/spec/unit/knife/winrm_session_spec.rb
+++ b/spec/unit/knife/winrm_session_spec.rb
@@ -26,8 +26,13 @@ describe Chef::Knife::WinrmSession do
   let(:options) { { transport: :plaintext } }
 
   before do
+    @original_config = Chef::Config.hash_dup
     allow(WinRM::WinRMWebService).to receive(:new).and_return(winrm_service)
     allow(winrm_service).to receive(:set_timeout)
+  end
+
+  after do
+    Chef::Config.configuration = @original_config
   end
 
   subject { Chef::Knife::WinrmSession.new(options) }
@@ -39,6 +44,19 @@ describe Chef::Knife::WinrmSession do
       it "uses winrm-s" do
         expect(Chef::Knife::WinrmSession).to receive(:load_windows_specific_gems)
         subject
+      end
+    end
+
+    context "when a proxy is configured" do
+      let(:proxy_uri) { 'blah.com' }
+
+      before do
+        Chef::Config[:http_proxy] = proxy_uri
+      end
+
+      it "sets the http_proxy to the configured proxy" do
+        subject
+        expect(ENV['HTTP_PROXY']).to eq("http://#{proxy_uri}")
       end
     end
   end


### PR DESCRIPTION
The `http_proxy` config value set in client.rb or knife.rb is the ubiquitous way to define the proxy to use for outgoing traffic from local calls into the chef API.  See https://github.com/chef/chef/blob/master/lib/chef/http/basic_client.rb#L99 and https://github.com/chef/chef/blob/master/lib/chef/http/basic_client.rb#L140. 

This covers all chef client to chef server communication in `chef-client` runs and includes the `knife bootstrap` http calls to the chef server. Its the same config value that the `bootstrap_proxy` argument of `knife bootstrap` sets on a bootstrapped node's client.rb. 

`knife winrm` and `knife windows bootstrap` calls do not currently leverage this config setting because their calls don't go through the chef http APIs but go through the winrm gem. The winrm gem does not explicitly create `Net::HTTP.Proxy` like the chef http api but `Net::HTTP` will check `HTTP_PROXY` environment variables and use the URI set there to create a proxy. See http://ruby-doc.org/stdlib-2.2.3/libdoc/net/http/rdoc/Net/HTTP.html.

A couple of the chef commands set these environment variables up front to influence any http call during the command's lifetime in case other http APIs are leveraged. These include chef `apply`, `client` and `solo` but not `knife`. One possible fix would be to have `Chef::Application::Knife` include a call to `configure_proxy_environment_variables`. This PR minimizes the potential impact of such a change and limits this behavior to the winrm calls in knife-windows`.

This is the sensible thing to do since winrm uses http as its transport and therefore needs this same proxy handling in order to respect the local `http_proxy` config settings.