### PR TITLE
functioning stake for winrm --ssl-peer-fingerprint

### DIFF
--- a/lib/chef/knife/winrm_base.rb
+++ b/lib/chef/knife/winrm_base.rb
@@ -101,6 +101,10 @@ class Chef
             :default => :verify_peer,
             :proc => Proc.new { |verify_mode| verify_mode.to_sym }
 
+          option :ssl_peer_fingerprint,
+            :long => "--ssl-peer-fingerprint FINGERPRINT",
+            :description => "Ssl Cert Fingerprint to bypass normal cert chain checks"
+
           option :winrm_authentication_protocol,
             :long => "--winrm-authentication-protocol AUTHENTICATION_PROTOCOL",
             :description => "The authentication protocol used during WinRM communication. The supported protocols are #{WINRM_AUTH_PROTOCOL_LIST.join(',')}. Default is 'negotiate'.",

--- a/lib/chef/knife/winrm_knife_base.rb
+++ b/lib/chef/knife/winrm_knife_base.rb
@@ -124,7 +124,8 @@ class Chef
               basic_auth_only: resolve_winrm_basic_auth,
               disable_sspi: resolve_winrm_disable_sspi,
               transport: resolve_winrm_transport,
-              no_ssl_peer_verification: resolve_no_ssl_peer_verification
+              no_ssl_peer_verification: resolve_no_ssl_peer_verification,
+              ssl_peer_fingerprint: resolve_ssl_peer_fingerprint
             }
             if @session_opts[:transport] == :kerberos
               @session_opts.merge!(resolve_winrm_kerberos_options)
@@ -177,6 +178,10 @@ class Chef
 
           def resolve_no_ssl_peer_verification
             locate_config_value(:ca_trust_file).nil? && config[:winrm_ssl_verify_mode] == :verify_none && resolve_winrm_transport == :ssl
+          end
+
+          def resolve_ssl_peer_fingerprint
+            locate_config_value(:ssl_peer_fingerprint)
           end
 
           def resolve_winrm_disable_sspi

--- a/lib/chef/knife/winrm_session.rb
+++ b/lib/chef/knife/winrm_session.rb
@@ -31,7 +31,7 @@ class Chef
         @endpoint = "#{scheme}://#{url}"
         
         opts = Hash.new
-        opts = {:user => options[:user], :pass => options[:password], :basic_auth_only => options[:basic_auth_only], :disable_sspi => options[:disable_sspi], :no_ssl_peer_verification => options[:no_ssl_peer_verification]}
+        opts = {:user => options[:user], :pass => options[:password], :basic_auth_only => options[:basic_auth_only], :disable_sspi => options[:disable_sspi], :no_ssl_peer_verification => options[:no_ssl_peer_verification], :ssl_peer_fingerprint => options[:ssl_peer_fingerprint]}
         options[:transport] == :kerberos ? opts.merge!({:service => options[:service], :realm => options[:realm], :keytab => options[:keytab]}) : opts.merge!({:ca_trust_path => options[:ca_trust_path]})
 
         Chef::Log.debug("WinRM::WinRMWebService options: #{opts}")


### PR DESCRIPTION
Should fix feature #298 