### PR TITLE
defer nokogiri require

### DIFF
--- a/lib/chef/knife/wsman_test.rb
+++ b/lib/chef/knife/wsman_test.rb
@@ -17,11 +17,9 @@
 #
 
 require 'httpclient'
-require 'nokogiri'
 require 'chef/knife'
 require 'chef/knife/winrm_knife_base'
 require 'chef/knife/wsman_endpoint'
-require 'pry'
 
 class Chef
   class Knife
@@ -66,6 +64,7 @@ class Chef
           if response.nil? || output_object.response_status_code != 200
             error_message = "No valid WSMan endoint listening at #{item.endpoint}."
           else
+            require 'nokogiri'
             doc = Nokogiri::XML response.body
             namespace = 'http://schemas.dmtf.org/wbem/wsman/identity/1/wsmanidentity.xsd'
             output_object.protocol_version = doc.xpath('//wsmid:ProtocolVersion', 'wsmid' => namespace).text


### PR DESCRIPTION
ChefDK carries along 2 versions of nokogiri and the older one is hard pinned to mini_portile 0.6.0 so we also get 2 versions of mini_portile as well which is what eventually causes this warning. The root problem to be addressed separately is the fact that chefDK grabs 2 versions of nokogiri and based on a `gem dependency -R nokogiri` there appears to be no good reason for this and we should just get the latter.

However I see this as a worthwhile change to quicky fix the problem here and deferring gem loading is a good thing in this case.