### PR TITLE
Feature: knife-windows should support --no-encryption flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # knife-windows Change Log
 
+## Unreleased
+* New feature `--winrm-no-encryption` option for explicit control of WinRM encryption
+
 ## Release 1.0.0
 
 * [knife-windows #281](https://github.com/chef/knife-windows/pull/281) Prevent unencrypted negotiate auth, automatically prefix local usernames with '.' for negotiate
@@ -74,4 +77,3 @@ Release Notes - Knife Windows Plugin - Version 0.5.4
 
 ** New Feature
     * [KNIFE\_WINDOWS-6] - default bootstrap template should support encrypted\_data\_bag\_secret
-

--- a/DOC_CHANGES.md
+++ b/DOC_CHANGES.md
@@ -5,6 +5,15 @@ Example Doc Change:
 ### Headline for the required change
 Description of the required change.
 -->
+# Unreleased
+
+### New WinRM option `winrm-no-encryption` to turn off encryption
+If the 'winrm-no-encryption' flag is specified,
+`knife-windows` subcommands that use WinRM will default to using
+plaintext transport, and turn off encryption negotiation on the WinRM
+session. In addition, any warnings regarding use of plaintext transport will
+be suppressed.
+
 # knife-windows 1.0.0 doc changes
 
 ### New bootstrap download and installation options
@@ -156,7 +165,7 @@ be replaced with the `--cert-thumbprint` option to use the generated
 certificate's thumbprint to identify the certificate with which the listener
 should be configured:
 
-    knife windows cert generate --domain myorg.org --output-file $env:userprofile/winrmcerts/winrm-ssl 
+    knife windows cert generate --domain myorg.org --output-file $env:userprofile/winrmcerts/winrm-ssl
     knife windows cert install $env:userprofile/winrmcerts/winrm-ssl
     knife windows listener create --hostname *.myorg.org --cert-thumbprint 1F3A70E2601FA1576BC4850ED2D7EF6587076423
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,9 @@ Example Note:
 ## Example Heading
 Details about the thing that changed that needs to get included in the Release Notes in markdown.
 -->
+## Unreleased
+* New feature `--winrm-no-encryption` option for explicit control of WinRM encryption
+
 # knife-windows 1.0.0 release notes:
 This release of knife-windows includes new features to improve authentication,
 simplify use of the WinRM SSL transport, install and download Chef
@@ -79,4 +82,3 @@ for the list of issues fixed in this release.
 ## knife-windows on RubyGems and Github
 https://rubygems.org/gems/knife-windows
 https://github.com/chef/knife-windows
-

--- a/lib/chef/knife/winrm_base.rb
+++ b/lib/chef/knife/winrm_base.rb
@@ -59,6 +59,12 @@ class Chef
             :proc => Proc.new { |transport| Chef::Config[:knife][:winrm_port] = '5986' if transport == 'ssl'
                                 Chef::Config[:knife][:winrm_transport] = transport }
 
+          option :winrm_no_encryption,
+            :short => "-n",
+            :long => "--winrm-no-encryption",
+            :description => "Flag to force no encryption and no authentication protocol negotiation for WinRM",
+            :proc => Proc.new { |key| Chef::Config[:knife][:winrm_no_encryption] = true }
+
           option :winrm_port,
             :short => "-p PORT",
             :long => "--winrm-port PORT",

--- a/lib/chef/knife/winrm_knife_base.rb
+++ b/lib/chef/knife/winrm_knife_base.rb
@@ -162,8 +162,8 @@ class Chef
           end
 
           def resolve_winrm_basic_auth
-            locate_config_value(:winrm_authentication_protocol) == "basic" ||
-            locate_config_value(:winrm_no_encryption)
+            (locate_config_value(:winrm_authentication_protocol) == "basic") ||
+            (locate_config_value(:winrm_no_encryption) == true)
           end
 
           def resolve_winrm_kerberos_options
@@ -200,8 +200,8 @@ class Chef
           end
 
           def negotiate_auth?
-            locate_config_value(:winrm_authentication_protocol) == "negotiate" &&
-            !locate_config_value(:winrm_no_encryption)
+            (locate_config_value(:winrm_authentication_protocol) == "negotiate") &&
+            (locate_config_value(:winrm_no_encryption) != true)
           end
 
           def warn_no_ssl_peer_verification

--- a/spec/unit/knife/bootstrap_options_spec.rb
+++ b/spec/unit/knife/bootstrap_options_spec.rb
@@ -111,6 +111,7 @@ expected: #{expected}
       :session_timeout,
       :winrm_authentication_protocol,
       :winrm_transport,
+      :winrm_no_encryption,
     ] }
 
     include_examples 'compare_options'


### PR DESCRIPTION
This change add a new '--no-encryption' flag that can be specified with 'knife winrm' and 'knife bootstrap windows winrm'.  If this flag is set, it sets the transport to be 'plaintext', and turns off SSPI negotiation. This flag is not compatible with the winrm transport set to 'ssl' - it will emit an error and exit in that case.
