### PR TITLE
make knife-windows backwards compatible with most current chef clients

### DIFF
--- a/lib/chef/knife/bootstrap_windows_base.rb
+++ b/lib/chef/knife/bootstrap_windows_base.rb
@@ -273,7 +273,9 @@ class Chef
         end
 
         validate_name_args!
-        validate_options!
+
+        # adding respond_to? so this works with pre 12.4 chef clients
+        validate_options! if respond_to?(:validate_options!)
 
         @node_name = Array(@name_args).first
         # back compat--templates may use this setting:


### PR DESCRIPTION
The policy file work introduced a new `validate_options!` method in `Knife::Bootstrap` that this calls in the `bootstrap` method. However, if using a pre 12.5 chef client, this method will not exist. So this PR adds that method to the bootstrap base module and simply calls `super` so if its in `Knife::Bootstrap` it will be called otherwise nothing happens.