### PR TITLE
ensure prompted password is passed to winrm session

### DIFF
--- a/lib/chef/knife/winrm.rb
+++ b/lib/chef/knife/winrm.rb
@@ -56,7 +56,6 @@ class Chef
         STDOUT.sync = STDERR.sync = true        
 
         configure_session
-        validate_password
         execute_remote_command        
       end
 

--- a/lib/chef/knife/winrm_knife_base.rb
+++ b/lib/chef/knife/winrm_knife_base.rb
@@ -93,12 +93,6 @@ class Chef
             end
           end
 
-          def validate_password
-            if @session_opts[:user] and (not @session_opts[:password])
-              @session_opts[:password] = Chef::Config[:knife][:winrm_password] = config[:winrm_password] = get_password
-            end
-          end
-
           private
 
           def session_from_list
@@ -126,9 +120,15 @@ class Chef
               transport: resolve_winrm_transport,
               no_ssl_peer_verification: resolve_no_ssl_peer_verification
             }
+
+            if @session_opts[:user] and (not @session_opts[:password])
+              @session_opts[:password] = Chef::Config[:knife][:winrm_password] = config[:winrm_password] = get_password
+            end
+
             if @session_opts[:transport] == :kerberos
               @session_opts.merge!(resolve_winrm_kerberos_options)
             end
+
             @session_opts[:ca_trust_path] = locate_config_value(:ca_trust_file) if locate_config_value(:ca_trust_file)
           end
 

--- a/spec/functional/bootstrap_download_spec.rb
+++ b/spec/functional/bootstrap_download_spec.rb
@@ -82,7 +82,7 @@ describe 'Knife::Windows::Core msi download functionality for knife Windows winr
       allow(mock_bootstrap_context).to receive(:local_download_path).and_return(@local_file_download_destination.gsub(::File::SEPARATOR, ::File::ALT_SEPARATOR))
 
       # Prevent password prompt during bootstrap process
-      allow(mock_winrm).to receive(:get_password).and_return(nil)
+      allow(mock_winrm.ui).to receive(:ask).and_return(nil)
       allow(Chef::Knife::Winrm).to receive(:new).and_return(mock_winrm)
 
       allow(Chef::Knife::Core::WindowsBootstrapContext).to receive(:new).and_return(mock_bootstrap_context)
@@ -134,6 +134,7 @@ describe 'Knife::Windows::Core msi download functionality for knife Windows winr
 
     allow(winrm_bootstrapper).to receive(:wait_for_remote_response)
     allow(winrm_bootstrapper).to receive(:validate_options!)
+    allow(winrm_bootstrapper.ui).to receive(:ask).and_return(nil)
     winrm_bootstrapper.config[:template_file] = @template_file_path
     winrm_bootstrapper.config[:run_list] = []
     # Execute the commands locally that would normally be executed via WinRM


### PR DESCRIPTION
There is currently a bug in v1.0 that does not pass the prompted password to the winrm session.