### PR TITLE
retrofit proxy configuration to work with 12.6

### DIFF
--- a/lib/chef/knife/winrm_session.rb
+++ b/lib/chef/knife/winrm_session.rb
@@ -25,7 +25,8 @@ class Chef
       attr_reader :host, :endpoint, :port, :output, :error, :exit_code
 
       def initialize(options)
-        Chef::Application.new.configure_proxy_environment_variables
+        configure_proxy
+        
         @host = options[:host]
         @port = options[:port]
         url = "#{options[:host]}:#{options[:port]}/wsman"
@@ -57,6 +58,8 @@ class Chef
         Chef::Log.debug("#{@host}[#{remote_id}] => :shell_close")
       end
 
+      private
+
       def get_output(remote_id, command_id)
         @winrm_session.get_command_output(remote_id, command_id) do |out,error|
           print_data(@host, out) if out
@@ -70,6 +73,14 @@ class Chef
         elsif !data.nil?
           print Chef::Knife::Winrm.ui.color(host, color)
           puts " #{data}"
+        end
+      end
+
+      def configure_proxy
+        if Chef::Config.respond_to?(:export_proxies)
+          Chef::Config.export_proxies
+        else
+          Chef::Application.new.configure_proxy_environment_variables
         end
       end
 

--- a/spec/unit/knife/bootstrap_options_spec.rb
+++ b/spec/unit/knife/bootstrap_options_spec.rb
@@ -95,6 +95,8 @@ expected: #{expected}
       :use_sudo,
       :use_sudo_password,
       :encrypt, # irrelevant during bootstrap
+      :identity_file,
+      :ssh_identity_file,
     ]}
 
     # win_ignore: Options in windows that aren't relevant to core.


### PR DESCRIPTION
this fixes #323 broken by https://github.com/chef/chef/commit/85d0407a16fa4dfc479d550a96355a6d11f4f551