### PR TITLE
drop winrm-s dependency and allow both windows and linux to use negotiate auth

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,9 @@ source "https://rubygems.org"
 # Specify your gem's dependencies in knife-windows.gemspec
 gemspec
 
+gem 'winrm', git: 'https://github.com/WinRb/WinRM', branch: 'dan/ntlm-encryption-squashed'
+gem 'rubyntlm', git: 'https://github.com/mwrock/rubyntlm.git', branch: 'domain'
+
 group :test do
   gem "chef"
   gem "rspec", '~> 3.0'

--- a/Gemfile
+++ b/Gemfile
@@ -3,9 +3,6 @@ source "https://rubygems.org"
 # Specify your gem's dependencies in knife-windows.gemspec
 gemspec
 
-gem 'winrm', git: 'https://github.com/WinRb/WinRM', branch: 'dan/ntlm-encryption-squashed'
-gem 'rubyntlm', git: 'https://github.com/mwrock/rubyntlm.git', branch: 'domain'
-
 group :test do
   gem "chef"
   gem "rspec", '~> 3.0'

--- a/README.md
+++ b/README.md
@@ -282,16 +282,12 @@ remote system's certificate can subject knife commands to spoofing attacks.
 ## WinRM authentication
 
 The default authentication protocol for `knife-windows` subcommands that use
-WinRM is the Negotiate protocol. The following commands when executed on a
-Windows system show authentication for domain and local accounts respectively:
+WinRM is the Negotiate protocol. The following commands show authentication for domain and local accounts respectively:
 
     knife bootstrap windows winrm web1.cloudapp.net -r "server::web" -x "proddomain\webuser" -P "super_secret_password"
     knife bootstrap windows winrm db1.cloudapp.net -r "server::db" -x "localadmin" -P "super_secret_password"
 
-The commands above are using the default plaintext transport for WinRM --
-the default of Negotiate authentication may not be fully supported on
-non-Windows systems using the plaintext transport. To work around this, the
-remote system can be configured with an SSL WinRM listener instead of a
+The remote system may also be configured with an SSL WinRM listener instead of a
 plaintext listener. Then the above commands should be modified to use the SSL
 transport as follows using the `-t` (or `--winrm-transport`) option with the
 `ssl` argument:
@@ -299,20 +295,16 @@ transport as follows using the `-t` (or `--winrm-transport`) option with the
     knife bootstrap windows winrm -t ssl web1.cloudapp.net -r "server::web" -x "proddomain\webuser" -P "super_secret_password" -f ~/mycert.crt
     knife bootstrap windows winrm -t ssl db1.cloudapp.net -r "server::db" -x "localadmin" -P "super_secret_password" ~/mycert.crt
 
-The commands using SSL above will work from any operating system, not
-just Windows.
-
 ### Troubleshooting authentication
 
-For development and testing purposes, unencrypted traffic with Basic
-authentication can make it easier to test connectivity. The configuration for
+Unencrypted traffic with Basic authentication should only be used for low level wire protocol debugging. The configuration for plain text connectivity to
 the remote system may be accomplished with the following PowerShell commands:
 
 ```powershell
 set-item wsman:\localhost\service\allowunencrypted $true
 set-item wsman:\localhost\service\auth\basic $true
 ```
-To test connectivity via `knife-windows` from another system, the default
+To use basic authentication connectivity via `knife-windows`, the default
 authentication protocol of Negotiate must be overridden using the
 `--winrm-authentication-protocol` option with the desired protocol, in this
 case Basic:
@@ -325,23 +317,12 @@ authentication; an account local to the remote system must be used.
 ### Platform WinRM authentication support
 
 `knife-windows` supports `Kerberos`, `Negotiate`, and `Basic` authentication
-for WinRM communication. However, some of these protocols
-may not work with `knife-windows` on non-Windows systems because
-`knife-windows` relies on operating system libraries such as GSSAPI to implement
-Windows authentication, and some versions of these libraries do not
-fully implement the protocols.
+for WinRM communication.
 
 The following table shows the authentication protocols that can be used with
 `knife-windows` depending on whether the knife workstation is a Windows
 system, the transport, and whether or not the target user is a domain user or
 local to the target Windows system.
-
-| Workstation OS / Account Scope | SSL                          | Plaintext                  |
-|--------------------------------|------------------------------|----------------------------|
-| Windows / Local                | Kerberos, Negotiate* , Basic | Kerberos, Negotiate, Basic |
-| Windows / Domain               | Kerberos, Negotiate          | Kerberos, Negotiate        |
-| Non-Windows / Local            | Kerberos, [Negotiate*](https://github.com/chef/knife-windows/issues/176) Basic | Kerberos, Basic |
-| Non-Windows / Domain           | Kerberos, Negotiate          | Kerberos                   |
 
 > \* There is a known defect in the `knife winrm` and `knife bootstrap windows
 > winrm` subcommands invoked on any OS  platform when authenticating with the Negotiate protocol over
@@ -354,9 +335,7 @@ local to the target Windows system.
 > This is generally not an issue for bootstrap scenarios, where the
 > system has yet to be joined to any domain, but can be a problem for remote
 > management cases after the system is domain joined. Workarounds include using
-> a domain account instead, or enabling Basic authentication on the remote
-> system (unencrypted communication **does not** need to be enabled to make
-> Basic authentication function over SSL).
+> a domain account instead or bypassing SSL and using Negotiate authentication.
 
 ## General troubleshooting
 

--- a/knife-windows.gemspec
+++ b/knife-windows.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.description = s.summary
 
   s.required_ruby_version	= ">= 1.9.1"
-  s.add_dependency "winrm", "~> 1.5"
+  s.add_dependency "winrm", "~> 1.6"
   s.add_dependency "nokogiri"
 
   s.add_development_dependency 'pry'

--- a/knife-windows.gemspec
+++ b/knife-windows.gemspec
@@ -15,7 +15,6 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version	= ">= 1.9.1"
   s.add_dependency "winrm", "~> 1.5"
-  s.add_dependency "winrm-s", "~> 0.3.4"
   s.add_dependency "nokogiri"
 
   s.add_development_dependency 'pry'

--- a/lib/chef/knife/winrm_session.rb
+++ b/lib/chef/knife/winrm_session.rb
@@ -41,7 +41,6 @@ class Chef
         Chef::Log.debug("Endpoint: #{endpoint}")
         Chef::Log.debug("Transport: #{options[:transport]}")
         
-        WinrmSession.load_windows_specific_gems if options[:transport] == :sspinegotiate
         @winrm_session = WinRM::WinRMWebService.new(@endpoint, options[:transport], opts)
         @winrm_session.set_timeout(options[:operation_timeout]) if options[:operation_timeout]
       end
@@ -82,12 +81,6 @@ class Chef
         else
           Chef::Application.new.configure_proxy_environment_variables
         end
-      end
-
-      def self.load_windows_specific_gems
-        #checking for windows in case testing on linux
-        require 'winrm-s'
-        Chef::Log.debug("Applied 'winrm-s' monkey patch and trying WinRM communication with 'sspinegotiate'")
       end
     end
   end

--- a/spec/unit/knife/winrm_session_spec.rb
+++ b/spec/unit/knife/winrm_session_spec.rb
@@ -38,15 +38,6 @@ describe Chef::Knife::WinrmSession do
   subject { Chef::Knife::WinrmSession.new(options) }
 
   describe "#initialize" do
-    context "when using sspinegotiate transport" do
-      let(:options) { { transport: :sspinegotiate } }
-
-      it "uses winrm-s" do
-        expect(Chef::Knife::WinrmSession).to receive(:load_windows_specific_gems)
-        subject
-      end
-    end
-
     context "when a proxy is configured" do
       let(:proxy_uri) { 'blah.com' }
 


### PR DESCRIPTION
This is a WIP PR dependent on the following downstream PRs:
https://github.com/WinRb/rubyntlm/pull/26
https://github.com/WinRb/WinRM/pull/144

The above PRs allow the winrm gem to provide sspinegotiate authentication and eliminates the need for the winrm-s monkey patches. the winrm changes work with the current httpclent API as is injecting the appropriate headers so no patches needed for httpclient. Further, the winrm changes leverage the rubyntlm gem which implements negotiate authentication in pure ruby. This allows us to leverage negotiate on linux workstations and do away with the OS checks and warnings regarding plaintext on linux.

cc @sneal @zenchild