### PR TITLE
Add fips flag to boostrap

### DIFF
--- a/lib/chef/knife/bootstrap_windows_base.rb
+++ b/lib/chef/knife/bootstrap_windows_base.rb
@@ -200,6 +200,11 @@ class Chef
             :description => "Comma separated list of tags to apply to the node",
             :proc => lambda { |o| o.split(/[\s,]+/) },
             :default => []
+
+          option :fips,
+            :long => "--fips",
+            :description => "Set openssl to run in fips mode",
+            :boolean => true
         end
       end
 

--- a/lib/chef/knife/core/windows_bootstrap_context.rb
+++ b/lib/chef/knife/core/windows_bootstrap_context.rb
@@ -136,6 +136,10 @@ CONFIG
             client_rb << %Q{trusted_certs_dir "c:/chef/trusted_certs"\n}
           end
 
+          if @config[:fips]
+            client_rb << %Q{fips true\n}
+          end
+
           escape_and_echo(client_rb)
         end
 


### PR DESCRIPTION
This is required to make the tests pass for chef-client
changes