### PR TITLE
fixes wsman test and death to nokogiri

### DIFF
--- a/knife-windows.gemspec
+++ b/knife-windows.gemspec
@@ -15,7 +15,6 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version	= ">= 1.9.1"
   s.add_dependency "winrm", "~> 1.6"
-  s.add_dependency "nokogiri"
 
   s.add_development_dependency 'pry'
 

--- a/lib/chef/knife/wsman_test.rb
+++ b/lib/chef/knife/wsman_test.rb
@@ -69,7 +69,7 @@ class Chef
             output_object.product_version  = search_xpath(doc, "//wsmid:ProductVersion")
             output_object.product_vendor  = search_xpath(doc, "//wsmid:ProductVendor")
             if output_object.protocol_version.to_s.strip.length == 0
-              error_message = "Endpoint #{item.endpoint} on #{item.host} does not appear to be a WSMAN endpoint."
+              error_message = "Endpoint #{item.endpoint} on #{item.host} does not appear to be a WSMAN endpoint. Response body was #{response.body}"
             end
           end
 

--- a/lib/chef/knife/wsman_test.rb
+++ b/lib/chef/knife/wsman_test.rb
@@ -56,6 +56,7 @@ class Chef
           error_message = nil
           begin
             client = HTTPClient.new
+            client.ssl_config.verify_mode = OpenSSL::SSL::VERIFY_NONE if resolve_no_ssl_peer_verification
             response = client.post(item.endpoint, xml, header)
           rescue Exception => e
             error_message = e.message

--- a/lib/chef/knife/wsman_test.rb
+++ b/lib/chef/knife/wsman_test.rb
@@ -34,7 +34,10 @@ class Chef
       banner "knife wsman test QUERY (options)"
 
       def run
-        @config[:winrm_authentication_protocol] = 'basic'
+        # pass a dummy password to avoid prompt for password
+        # but it does nothing
+        @config[:winrm_password] = 'cute_little_kittens'
+
         configure_session
         verify_wsman_accessiblity_for_nodes
       end
@@ -62,7 +65,7 @@ class Chef
           end
 
           if response.nil? || output_object.response_status_code != 200
-            error_message = "No valid WSMan endoint listening at #{item.endpoint}."
+            error_message = "No valid WSMan endoint listening at #{item.endpoint}. Error returned from endpoint: #{error_message}"
           else
             doc = REXML::Document.new(response.body)
             output_object.protocol_version = search_xpath(doc, "//wsmid:ProtocolVersion")

--- a/spec/unit/knife/wsman_test_spec.rb
+++ b/spec/unit/knife/wsman_test_spec.rb
@@ -117,6 +117,20 @@ describe Chef::Knife::WsmanTest do
       end
     end
 
+    context 'with an invalid body' do
+      let(:http_client_mock) {HTTPClient.new}
+
+      it 'includes invalid body in error message' do
+        response_body = 'I am invalid'
+        http_response_mock = HTTP::Message.new_response(response_body)
+        allow(http_client_mock).to receive(:post).and_return(http_response_mock)
+        expect(subject).to receive(:output) do |output|
+          expect(output.error_message).to  match(/#{response_body}/)
+        end
+        subject.run
+      end
+    end
+
     context 'and the target node is Windows Server 2008 R2' do
       before(:each) do
         ws2008r2_response_body = '<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope"><s:Header/><s:Body><wsmid:IdentifyResponse xmlns:wsmid="http://schemas.dmtf.org/wbem/wsman/identity/1/wsmanidentity.xsd"><wsmid:ProtocolVersion>http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd</wsmid:ProtocolVersion><wsmid:ProductVendor>Microsoft Corporation</wsmid:ProductVendor><wsmid:ProductVersion>OS: 0.0.0 SP: 0.0 Stack: 2.0</wsmid:ProductVersion></wsmid:IdentifyResponse></s:Body></s:Envelope>'

--- a/spec/unit/knife/wsman_test_spec.rb
+++ b/spec/unit/knife/wsman_test_spec.rb
@@ -111,19 +111,19 @@ describe Chef::Knife::WsmanTest do
       it 'returns an object with an error message' do
         error_message = 'A connection attempt failed because the connected party did not properly respond after a period of time.'
         allow(http_client_mock_verbose).to receive(:post).and_raise(Exception.new(error_message))
-        expect(subject).to receive(:output).with(duck_type(:error_message))
         expect(subject).to receive(:exit).with(1)
+        expect(subject).to receive(:output) do |output|
+          expect(output.error_message).to  match(/#{error_message}/)
+        end
         subject.run
       end
     end
 
     context 'with an invalid body' do
-      let(:http_client_mock) {HTTPClient.new}
-
       it 'includes invalid body in error message' do
         response_body = 'I am invalid'
         http_response_mock = HTTP::Message.new_response(response_body)
-        allow(http_client_mock).to receive(:post).and_return(http_response_mock)
+        allow(http_client_mock_verbose).to receive(:post).and_return(http_response_mock)
         expect(subject).to receive(:output) do |output|
           expect(output.error_message).to  match(/#{response_body}/)
         end

--- a/spec/unit/knife/wsman_test_spec.rb
+++ b/spec/unit/knife/wsman_test_spec.rb
@@ -41,7 +41,6 @@ describe Chef::Knife::WsmanTest do
       error_message = 'A connection attempt failed because the connected party did not properly respond after a period of time.'
 
       before(:each) do
-        allow(HTTPClient).to receive(:new).and_return(http_client_mock)
         allow(http_client_mock).to receive(:post).and_raise(Exception.new(error_message))
       end
 


### PR DESCRIPTION
This makes the following fixes to `wsman test`:
* Do not swallow deeper http errors but send to verbode
* Do not prompt for password
* honor `--winrm-ssl-verify-mode verify_none`
* replace nokogiri with rexml