### PR TITLE
add more guidance around possible ssl verification issues

### DIFF
--- a/lib/chef/knife/wsman_test.rb
+++ b/lib/chef/knife/wsman_test.rb
@@ -42,51 +42,29 @@ class Chef
         verify_wsman_accessiblity_for_nodes
       end
 
+      private
+
       def verify_wsman_accessiblity_for_nodes
         error_count = 0
         @winrm_sessions.each do |item|
           Chef::Log.debug("checking for WSMAN availability at #{item.endpoint}")
 
-          xml = '<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope" xmlns:wsmid="http://schemas.dmtf.org/wbem/wsman/identity/1/wsmanidentity.xsd"><s:Header/><s:Body><wsmid:Identify/></s:Body></s:Envelope>'
-          header = {
-            'WSMANIDENTIFY' => 'unauthenticated',
-            'Content-Type' => 'application/soap+xml; charset=UTF-8'
-          }
-          output_object = Chef::Knife::WsmanEndpoint.new(item.host, item.port, item.endpoint)
-          error_message = nil
           ssl_error = nil
           begin
-            client = HTTPClient.new
-            client.ssl_config.verify_mode = OpenSSL::SSL::VERIFY_NONE if resolve_no_ssl_peer_verification
-            response = client.post(item.endpoint, xml, header)
-          rescue OpenSSL::SSL::SSLError => ssl_error
-            error_message = ssl_error.message
-          rescue Exception => e
-            error_message = e.message
-          else
+            response = post_identity_request(item.endpoint)
             ui.msg "Connected successfully to #{item.host} at #{item.endpoint}."
-            output_object.response_status_code = response.status_code
+          rescue Exception => err
           end
 
-          if response.nil? || output_object.response_status_code != 200
-            error_message = "No valid WSMan endoint listening at #{item.endpoint}. Error returned from endpoint: #{error_message}"
-          else
-            doc = REXML::Document.new(response.body)
-            output_object.protocol_version = search_xpath(doc, "//wsmid:ProtocolVersion")
-            output_object.product_version  = search_xpath(doc, "//wsmid:ProductVersion")
-            output_object.product_vendor  = search_xpath(doc, "//wsmid:ProductVendor")
-            if output_object.protocol_version.to_s.strip.length == 0
-              error_message = "Endpoint #{item.endpoint} on #{item.host} does not appear to be a WSMAN endpoint. Response body was #{response.body}"
-            end
-          end
+          output_object = parse_response(item, response)
+          output_object.error_message += "\r\nError returned from endpoint: #{err.message}" if err
 
-          unless error_message.nil?
+          unless output_object.error_message.nil?
             ui.warn "Failed to connect to #{item.host} at #{item.endpoint}."
-            if ssl_error
+            if err && err.is_a?(OpenSSL::SSL::SSLError)
               ui.warn "Failure due to an issue with SSL likely cause would be unsuccesful certificate verification."
               ui.warn "Either ensure your certificate is valid or use '--winrm-ssl-verify-mode verify_none' to ignore verification failures."
             end
-            output_object.error_message = error_message
             error_count += 1
           end
 
@@ -98,6 +76,36 @@ class Chef
           ui.error "Failed to connect to #{error_count} nodes."
           exit 1
         end
+      end
+
+      def post_identity_request(endpoint)
+        xml = '<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope" xmlns:wsmid="http://schemas.dmtf.org/wbem/wsman/identity/1/wsmanidentity.xsd"><s:Header/><s:Body><wsmid:Identify/></s:Body></s:Envelope>'
+        header = {
+          'WSMANIDENTIFY' => 'unauthenticated',
+          'Content-Type' => 'application/soap+xml; charset=UTF-8'
+        }
+
+        client = HTTPClient.new
+        client.ssl_config.verify_mode = OpenSSL::SSL::VERIFY_NONE if resolve_no_ssl_peer_verification
+        client.post(endpoint, xml, header)
+      end
+
+      def parse_response(node, response)
+        output_object = Chef::Knife::WsmanEndpoint.new(node.host, node.port, node.endpoint)
+        output_object.response_status_code = response.status_code unless response.nil?
+
+        if response.nil? || response.status_code != 200
+          output_object.error_message = "No valid WSMan endoint listening at #{node.endpoint}."
+        else
+          doc = REXML::Document.new(response.body)
+          output_object.protocol_version = search_xpath(doc, "//wsmid:ProtocolVersion")
+          output_object.product_version  = search_xpath(doc, "//wsmid:ProductVersion")
+          output_object.product_vendor  = search_xpath(doc, "//wsmid:ProductVendor")
+          if output_object.protocol_version.to_s.strip.length == 0
+            output_object.error_message = "Endpoint #{node.endpoint} on #{node.host} does not appear to be a WSMAN endpoint. Response body was #{response.body}"
+          end
+        end
+        output_object
       end
 
       def search_xpath(document, property_name)

--- a/lib/chef/knife/wsman_test.rb
+++ b/lib/chef/knife/wsman_test.rb
@@ -62,7 +62,7 @@ class Chef
           unless output_object.error_message.nil?
             ui.warn "Failed to connect to #{item.host} at #{item.endpoint}."
             if err && err.is_a?(OpenSSL::SSL::SSLError)
-              ui.warn "Failure due to an issue with SSL likely cause would be unsuccesful certificate verification."
+              ui.warn "Failure due to an issue with SSL; likely cause would be unsuccesful certificate verification."
               ui.warn "Either ensure your certificate is valid or use '--winrm-ssl-verify-mode verify_none' to ignore verification failures."
             end
             error_count += 1


### PR DESCRIPTION
This change attempts to take some more "guess work" out of SSL verification errors. It also refactors the huge `verify_wsman_accessiblity_for_nodes` to smaller methods.