### PR TITLE
Knife bootstrap includes `fips true` when in fips mode

### DIFF
--- a/lib/chef/knife/core/windows_bootstrap_context.rb
+++ b/lib/chef/knife/core/windows_bootstrap_context.rb
@@ -136,6 +136,10 @@ CONFIG
             client_rb << %Q{trusted_certs_dir "c:/chef/trusted_certs"\n}
           end
 
+          if Chef::Config[:fips]
+            client_rb << %Q{fips true\n}
+          end
+
           escape_and_echo(client_rb)
         end
 

--- a/spec/unit/knife/core/windows_bootstrap_context_spec.rb
+++ b/spec/unit/knife/core/windows_bootstrap_context_spec.rb
@@ -25,6 +25,32 @@ describe Chef::Knife::Core::WindowsBootstrapContext do
      allow(Chef::Knife::Core::WindowsBootstrapContext).to receive(:new).and_return(mock_bootstrap_context)
    end
 
+  describe "fips" do
+    before do
+      Chef::Config[:fips] = fips_mode
+    end
+
+    after do
+      Chef::Config.reset!
+    end
+
+    context "when fips is set" do
+      let(:fips_mode) { true }
+
+      it "sets fips mode in the client.rb" do
+        expect(mock_bootstrap_context.config_content).to match(/fips true/)
+      end
+    end
+
+    context "when fips is not set" do
+      let(:fips_mode) { false }
+
+      it "sets fips mode in the client.rb" do
+        expect(mock_bootstrap_context.config_content).not_to match(/fips true/)
+      end
+    end
+  end
+
   describe "validation_key", :chef_gte_12_only do
     before do
       mock_bootstrap_context.instance_variable_set(:@config, Mash.new(:validation_key => "C:\\chef\\key.pem"))


### PR DESCRIPTION
If knife has set fips mode, make sure to add it to
the client.rb during bootstraps

Tested with basic auth + ssl transport

Some notes:
* ntlm authentication does not work. It uses MD4 and RC4
  at some point. When asking openssl to do any of these
  operations at any point while in fips mode, ruby will
  refuse the request and raise. What this means is that
  users will have to use basic auth over ssl or potentially
  kerberos.