### PR TITLE
add support for winrm's new  ssl fingerprint option

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,17 +280,9 @@ This option should be used carefully since disabling the verification of the
 remote system's certificate can subject knife commands to spoofing attacks.
 
 ##### Connecting securely to self-signed certs
-If you generate a self-signed cert, it is likely that the fqdn / ip do not match.
-In order to securely connect you must use the fingerprint which can be extracted from
-a listening server via the openssl s_client:
+If you generate a self-signed cert, the fqdn and ip may not match which will result in a certificate validation failure. In order to securely connect and reduce the risk of a "Man In The Middle" attack, you may use the certificate's fingerprint to precisely identify the known certificate on the WinRM endpoint. 
 
-    openssl s_client -showcerts -connect $IP:5986 < /dev/null 2>/dev/null | \
-						openssl x509 -sha1 -fingerprint -noout | sed -e 's/^.*=//;s/://g'
-						89255929FB4B5E1BFABF7E7F01AFAFC5E7003C3F
-
-The fingerprint can then be supplied to ```--ssl-peer-fingerprint``` and instead of
-using a certificate chain and comparing the CommonName, it will only verify that the
-fingerprint matches:
+The fingerprint can be supplied to ```--ssl-peer-fingerprint``` and instead of using a certificate chain and comparing the CommonName, it will only verify that the fingerprint matches:
 
     knife winrm --ssl-peer-fingerprint 89255929FB4B5E1BFABF7E7F01AFAFC5E7003C3F \
 		      -m $IP -x Administrator -P $PASSWD-t ssl --winrm-port 5986 hostname

--- a/lib/chef/knife/winrm_base.rb
+++ b/lib/chef/knife/winrm_base.rb
@@ -98,7 +98,7 @@ class Chef
 
           option :ssl_peer_fingerprint,
             :long => "--ssl-peer-fingerprint FINGERPRINT",
-            :description => "Ssl Cert Fingerprint to bypass normal cert chain checks"
+            :description => "ssl Cert Fingerprint to bypass normal cert chain checks"
 
           option :winrm_authentication_protocol,
             :long => "--winrm-authentication-protocol AUTHENTICATION_PROTOCOL",

--- a/lib/chef/knife/winrm_base.rb
+++ b/lib/chef/knife/winrm_base.rb
@@ -96,6 +96,10 @@ class Chef
             :default => :verify_peer,
             :proc => Proc.new { |verify_mode| verify_mode.to_sym }
 
+          option :ssl_peer_fingerprint,
+            :long => "--ssl-peer-fingerprint FINGERPRINT",
+            :description => "Ssl Cert Fingerprint to bypass normal cert chain checks"
+
           option :winrm_authentication_protocol,
             :long => "--winrm-authentication-protocol AUTHENTICATION_PROTOCOL",
             :description => "The authentication protocol used during WinRM communication. The supported protocols are #{WINRM_AUTH_PROTOCOL_LIST.join(',')}. Default is 'negotiate'.",

--- a/lib/chef/knife/winrm_knife_base.rb
+++ b/lib/chef/knife/winrm_knife_base.rb
@@ -198,7 +198,8 @@ class Chef
               basic_auth_only: resolve_winrm_basic_auth,
               disable_sspi: resolve_winrm_disable_sspi,
               transport: resolve_winrm_transport,
-              no_ssl_peer_verification: resolve_no_ssl_peer_verification
+              no_ssl_peer_verification: resolve_no_ssl_peer_verification,
+              ssl_peer_fingerprint: resolve_ssl_peer_fingerprint
             }
 
             if @session_opts[:user] and (not @session_opts[:password])
@@ -257,6 +258,10 @@ class Chef
 
           def resolve_no_ssl_peer_verification
             locate_config_value(:ca_trust_file).nil? && config[:winrm_ssl_verify_mode] == :verify_none && resolve_winrm_transport == :ssl
+          end
+
+          def resolve_ssl_peer_fingerprint
+            locate_config_value(:ssl_peer_fingerprint)
           end
 
           def resolve_winrm_disable_sspi

--- a/lib/chef/knife/winrm_session.rb
+++ b/lib/chef/knife/winrm_session.rb
@@ -34,7 +34,7 @@ class Chef
         @endpoint = "#{scheme}://#{url}"
         
         opts = Hash.new
-        opts = {:user => options[:user], :pass => options[:password], :basic_auth_only => options[:basic_auth_only], :disable_sspi => options[:disable_sspi], :no_ssl_peer_verification => options[:no_ssl_peer_verification]}
+        opts = {:user => options[:user], :pass => options[:password], :basic_auth_only => options[:basic_auth_only], :disable_sspi => options[:disable_sspi], :no_ssl_peer_verification => options[:no_ssl_peer_verification], :ssl_peer_fingerprint => options[:ssl_peer_fingerprint]}
         options[:transport] == :kerberos ? opts.merge!({:service => options[:service], :realm => options[:realm], :keytab => options[:keytab]}) : opts.merge!({:ca_trust_path => options[:ca_trust_path]})
 
         Chef::Log.debug("WinRM::WinRMWebService options: #{opts}")

--- a/spec/unit/knife/bootstrap_options_spec.rb
+++ b/spec/unit/knife/bootstrap_options_spec.rb
@@ -92,6 +92,7 @@ expected: #{expected}
       :forward_agent,
       :preserve_home,
       :ssh_gateway,
+      :ssl_peer_fingerprint,
       :use_sudo,
       :use_sudo_password,
       :encrypt, # irrelevant during bootstrap

--- a/spec/unit/knife/bootstrap_options_spec.rb
+++ b/spec/unit/knife/bootstrap_options_spec.rb
@@ -92,7 +92,6 @@ expected: #{expected}
       :forward_agent,
       :preserve_home,
       :ssh_gateway,
-      :ssl_peer_fingerprint,
       :use_sudo,
       :use_sudo_password,
       :encrypt, # irrelevant during bootstrap
@@ -112,6 +111,7 @@ expected: #{expected}
       :kerberos_service,
       :manual,
       :session_timeout,
+      :ssl_peer_fingerprint,
       :winrm_authentication_protocol,
       :winrm_transport,
       :fips, #until chef 12.7 is released


### PR DESCRIPTION
This adds a minor fixup to @hh's PR #298 and tweaks the readme just a bit.

The `ssl_fingerprint` option was added in winrm 1.6 and this makes it accessible from knife.