### PR TITLE
Update to same rubies that chef uses

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: ruby
 
 rvm:
-  - 1.9.3
-  - 2.0.0
+  - 2.1
+  - 2.2
 
 before_install:
   - gem install bundler
@@ -16,9 +16,9 @@ env:
 
 matrix:
   exclude:
-  - rvm: 1.9.3
+  - rvm: 2.1
     env: CHEF_VERSION="master"
-  - rvm: 1.9.3
+  - rvm: 2.1
     env: CHEF_VERSION="~> 12.0"
 
 branches:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,16 +8,13 @@ environment:
   bundle_gemfile: ci.gemfile
 
   matrix:
-    - ruby_version: "193"
+    - ruby_version: "20"
       chef_version: "< 12"
 
-    - ruby_version: "200"
-      chef_version: "< 12"
-
-    - ruby_version: "200"
+    - ruby_version: "21"
       chef_version: "~> 12.0"
 
-    - ruby_version: "200"
+    - ruby_version: "21"
       chef_version: "master"
 
 clone_folder: c:\projects\knife-windows
@@ -32,7 +29,7 @@ install:
   - echo %PATH%
   - ruby --version
   - gem --version
-  - gem install bundler --quiet --no-ri --no-rdoc
+  - gem install bundler -v 1.11.2 --quiet --no-ri --no-rdoc
   - bundler --version
 
 build_script:

--- a/spec/assets/win_template_rendered_with_bootstrap_install_command.txt
+++ b/spec/assets/win_template_rendered_with_bootstrap_install_command.txt
@@ -213,5 +213,5 @@ echo.# Using default node name ^(fqdn^)
 
 @echo Starting chef to bootstrap the node... 
 SET "PATH=%PATH%;C:\ruby\bin;C:\opscode\chef\bin;C:\opscode\chef\embedded\bin"
-chef-client -c c:/chef/client.rb -j c:/chef/first-boot.json -E _default
+chef-client -c c:/chef/client.rb -j c:/chef/first-boot.json
  

--- a/spec/assets/win_template_rendered_without_bootstrap_install_command.txt
+++ b/spec/assets/win_template_rendered_without_bootstrap_install_command.txt
@@ -325,5 +325,5 @@ echo.# Using default node name ^(fqdn^)
 
 @echo Starting chef to bootstrap the node... 
 SET "PATH=%PATH%;C:\ruby\bin;C:\opscode\chef\bin;C:\opscode\chef\embedded\bin"
-chef-client -c c:/chef/client.rb -j c:/chef/first-boot.json -E _default
+chef-client -c c:/chef/client.rb -j c:/chef/first-boot.json
  


### PR DESCRIPTION
travis and appveyor are failing due to chef-zero requiring ruby 2.1.0. Since chef only tests against 2.1 and 2.2 now, we'll do the same here.

I'm also pinning bundler since the latest is broken on windows but a new release is imminent: https://github.com/bundler/bundler/pull/4479#issuecomment-215901069