### PR TITLE
Honor the chef ssl_policy when making winrm calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # knife-windows Change Log
 
+## Release 1.4.1
+
+* [knife-windows #362](https://github.com/chef/knife-windows/pull/362) Fix `knife windows bootstrap` chef client downloads over a proxy
+* [knife-windows #367](https://github.com/chef/knife-windows/pull/367) Honor chef's ssl_policy when making winrm calls
+
 ## Release 1.4.0
 
 * [knife-windows #354](https://github.com/chef/knife-windows/pull/354) Allows the user to specify the architecture they want to install on the target system during `knife bootstrap windows`.  In your knife config specify `knife[:bootstrap_architecture]`.  Valid values are `:i386` for 32 bit or `:x86_64` for 64 bit.  By default the architecture will be whatever the target system is.  If you try to install a 64 bit package on a 32 bit system you will receive an error.

--- a/lib/chef/knife/winrm_session.rb
+++ b/lib/chef/knife/winrm_session.rb
@@ -44,7 +44,7 @@ class Chef
         @winrm_session = WinRM::WinRMWebService.new(@endpoint, options[:transport], opts)
         transport = @winrm_session.instance_variable_get(:@xfer)
         http_client = transport.instance_variable_get(:@httpcli)
-        Chef::HTTP::DefaultSSLPolicy.apply_to(http_client.ssl_config)
+        Chef::HTTP::DefaultSSLPolicy.new(http_client.ssl_config).set_custom_certs
         @winrm_session.set_timeout(options[:operation_timeout]) if options[:operation_timeout]
       end
 

--- a/lib/chef/knife/winrm_session.rb
+++ b/lib/chef/knife/winrm_session.rb
@@ -42,6 +42,9 @@ class Chef
         Chef::Log.debug("Transport: #{options[:transport]}")
 
         @winrm_session = WinRM::WinRMWebService.new(@endpoint, options[:transport], opts)
+        transport = @winrm_session.instance_variable_get(:@xfer)
+        http_client = transport.instance_variable_get(:@httpcli)
+        Chef::HTTP::DefaultSSLPolicy.apply_to(http_client.ssl_config)
         @winrm_session.set_timeout(options[:operation_timeout]) if options[:operation_timeout]
       end
 

--- a/lib/chef/knife/wsman_test.rb
+++ b/lib/chef/knife/wsman_test.rb
@@ -86,6 +86,7 @@ class Chef
         }
 
         client = HTTPClient.new
+        Chef::HTTP::DefaultSSLPolicy.apply_to(client.ssl_config)
         client.ssl_config.verify_mode = OpenSSL::SSL::VERIFY_NONE if resolve_no_ssl_peer_verification
         client.post(endpoint, xml, header)
       end

--- a/lib/chef/knife/wsman_test.rb
+++ b/lib/chef/knife/wsman_test.rb
@@ -86,7 +86,7 @@ class Chef
         }
 
         client = HTTPClient.new
-        Chef::HTTP::DefaultSSLPolicy.apply_to(client.ssl_config)
+        Chef::HTTP::DefaultSSLPolicy.new(client.ssl_config).set_custom_certs
         client.ssl_config.verify_mode = OpenSSL::SSL::VERIFY_NONE if resolve_no_ssl_peer_verification
         client.post(endpoint, xml, header)
       end

--- a/lib/knife-windows/version.rb
+++ b/lib/knife-windows/version.rb
@@ -1,6 +1,6 @@
 module Knife
   module Windows
-    VERSION = "1.4.0"
+    VERSION = "1.4.1"
     MAJOR, MINOR, TINY = VERSION.split('.')
   end
 end

--- a/spec/dummy_winrm_service.rb
+++ b/spec/dummy_winrm_service.rb
@@ -1,0 +1,24 @@
+module Dummy
+  class WinRMTransport
+    attr_reader :httpcli
+
+    def initialize
+      @httpcli = HTTPClient.new
+    end
+  end
+
+  class WinRMService
+    attr_reader :xfer
+
+    def initialize
+      @xfer = WinRMTransport.new
+    end
+
+    def set_timeout(timeout); end
+    def open_shell; end
+    def run_command; end
+    def get_command_output; end
+    def cleanup_command; end
+    def close_shell; end
+  end
+end

--- a/spec/unit/knife/winrm_session_spec.rb
+++ b/spec/unit/knife/winrm_session_spec.rb
@@ -41,6 +41,7 @@ describe Chef::Knife::WinrmSession do
   describe "#initialize" do
     context "when a proxy is configured" do
       let(:proxy_uri) { 'blah.com' }
+      let(:ssl_policy) { double('DefaultSSLPolicy', :set_custom_certs => nil) }
 
       before do
         Chef::Config[:http_proxy] = proxy_uri
@@ -52,8 +53,10 @@ describe Chef::Knife::WinrmSession do
       end
 
       it "sets the ssl policy on the winrm client" do
-        expect(Chef::HTTP::DefaultSSLPolicy).to receive(:apply_to)
+        expect(Chef::HTTP::DefaultSSLPolicy).to receive(:new)
           .with(winrm_service.xfer.httpcli.ssl_config)
+          .and_return(ssl_policy)
+        expect(ssl_policy).to receive(:set_custom_certs)
         subject
       end
 

--- a/spec/unit/knife/winrm_session_spec.rb
+++ b/spec/unit/knife/winrm_session_spec.rb
@@ -17,12 +17,13 @@
 #
 
 require 'spec_helper'
+require 'dummy_winrm_service'
 
 Chef::Knife::Winrm.load_deps
 
 
 describe Chef::Knife::WinrmSession do
-  let(:winrm_service) { double('WinRMWebService') }
+  let(:winrm_service) { Dummy::WinRMService.new }
   let(:options) { { transport: :plaintext } }
 
   before do
@@ -49,6 +50,13 @@ describe Chef::Knife::WinrmSession do
         subject
         expect(ENV['HTTP_PROXY']).to eq("http://#{proxy_uri}")
       end
+
+      it "sets the ssl policy on the winrm client" do
+        expect(Chef::HTTP::DefaultSSLPolicy).to receive(:apply_to)
+          .with(winrm_service.xfer.httpcli.ssl_config)
+        subject
+      end
+
     end
   end
 

--- a/spec/unit/knife/wsman_test_spec.rb
+++ b/spec/unit/knife/wsman_test_spec.rb
@@ -20,6 +20,7 @@ require 'spec_helper'
 
 describe Chef::Knife::WsmanTest do
   let(:http_client_mock) { HTTPClient.new }
+  let(:ssl_policy) { double('DefaultSSLPolicy', :set_custom_certs => nil) }
 
   before(:all) do
     Chef::Config.reset
@@ -32,12 +33,15 @@ describe Chef::Knife::WsmanTest do
     allow(HTTPClient).to receive(:new).and_return(http_client_mock)
     subject.config[:verbosity] = 0
     allow(subject.ui).to receive(:ask).and_return('prompted_password')
+    allow(Chef::HTTP::DefaultSSLPolicy).to receive(:new)
+      .with(http_client_mock.ssl_config)
+      .and_return(ssl_policy)
   end
 
   subject { Chef::Knife::WsmanTest.new(['-m', 'localhost']) }
 
   it 'sets the ssl policy' do
-    expect(Chef::HTTP::DefaultSSLPolicy).to receive(:apply_to).with(http_client_mock.ssl_config).twice
+    expect(ssl_policy).to receive(:set_custom_certs).twice
     subject.run
   end
 


### PR DESCRIPTION
Currently it is not possible for winrm calls to validate ssl certificates in the user's `trusted_certificates` folder. This has confused several users because while calls to `knife ssl check` leads ione to believe that a ssl certificate is trusted, subsequent bootstraps and `knife winrm` calls fail unless they turn off ssl validation.

This applies the `Chef::HTTP::DefaultSSLPolicy` to the winrm `HTTPClient` connection and therefore honors all certificates in the trusted_certs folder.

Admittedly the implementation here is quite hacky as it has to get to the `HTTPClient` via direct instance variable inspection. While I could expose those in winrm, that would require a minor version release and I'm trying to keep winrm releases at bay in order to focus on winrm v2.