### PR TITLE
Added code and corresponding RSpecs to read the json attributes from the --json-attributes-file option.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,4 +9,5 @@ group :test do
   gem "ruby-wmi"
   gem "httpclient"
   gem 'rake'
+  gem "rack", "< 2.0" # 2.0 requires Ruby 2.2+
 end

--- a/ci.gemfile
+++ b/ci.gemfile
@@ -13,3 +13,4 @@ gem "rspec", '~> 3.0'
 gem "ruby-wmi"
 gem "httpclient"
 gem 'rake'
+gem "rack", "< 2.0" # 2.0 requires Ruby 2.2+

--- a/lib/chef/knife/bootstrap_windows_base.rb
+++ b/lib/chef/knife/bootstrap_windows_base.rb
@@ -268,7 +268,12 @@ class Chef
         cli_secret_file || cli_secret || knife_secret_file || knife_secret
       end
 
+      def first_boot_attributes
+        config[:first_boot_attributes] || config[:first_boot_attributes_from_file] || {}
+      end
+
       def render_template(template=nil)
+        config[:first_boot_attributes] = first_boot_attributes
         config[:secret] = load_correct_secret
         Erubis::Eruby.new(template).evaluate(bootstrap_context)
       end

--- a/spec/unit/knife/bootstrap_windows_winrm_spec.rb
+++ b/spec/unit/knife/bootstrap_windows_winrm_spec.rb
@@ -341,15 +341,16 @@ describe Chef::Knife::BootstrapWindowsWinrm do
   end
 
   describe 'first_boot_attributes' do
-    before(:each) do
-      @first_boot_attributes = { 'a1' => 'b1', 'a2' => 'b2' }
-      @json_file = 'my_json.json'
-      File.open(@json_file,"w+") do |f|
+    let(:first_boot_attributes) { { 'a1' => 'b1', 'a2' => 'b2' } }
+    let(:json_file) { 'my_json.json' }
+    let(:first_boot_attributes_from_file) { read_json_file(json_file) }
+
+    before do
+      File.open(json_file,"w+") do |f|
         f.write <<-EOH
 {"b2" : "a3", "a4" : "b5"}
         EOH
       end
-      @first_boot_attributes_from_file = read_json_file(@json_file)
     end
 
     context 'when none of the json-attributes options are passed' do
@@ -361,7 +362,7 @@ describe Chef::Knife::BootstrapWindowsWinrm do
 
     context 'when only --json-attributes option is passed' do
       before do
-        bootstrap.config[:first_boot_attributes] = @first_boot_attributes
+        bootstrap.config[:first_boot_attributes] = first_boot_attributes
       end
 
       it 'returns the hash passed by the user in --json-attributes option' do
@@ -372,7 +373,7 @@ describe Chef::Knife::BootstrapWindowsWinrm do
 
     context 'when only --json-attribute-file option is passed' do
       before do
-        bootstrap.config[:first_boot_attributes_from_file] = @first_boot_attributes_from_file
+        bootstrap.config[:first_boot_attributes_from_file] = first_boot_attributes_from_file
       end
 
       it 'returns the hash passed by the user in --json-attribute-file option' do
@@ -383,8 +384,8 @@ describe Chef::Knife::BootstrapWindowsWinrm do
 
     context 'when both the --json-attributes option and --json-attribute-file options are passed' do
       before do
-        bootstrap.config[:first_boot_attributes] = @first_boot_attributes
-        bootstrap.config[:first_boot_attributes_from_file] = @first_boot_attributes_from_file
+        bootstrap.config[:first_boot_attributes] = first_boot_attributes
+        bootstrap.config[:first_boot_attributes_from_file] = first_boot_attributes_from_file
       end
 
       it 'returns the hash passed by the user in --json-attributes option' do
@@ -393,8 +394,8 @@ describe Chef::Knife::BootstrapWindowsWinrm do
       end
     end
 
-    after(:each) do
-      FileUtils.rm_rf @json_file
+    after do
+      FileUtils.rm_rf json_file
     end
   end
 


### PR DESCRIPTION
Done. json attributes passed through --json-attributes-file option were not getting set into config object and so the attributes passed were then missing from the first_boot.json file.