### PR TITLE
Fix for architechture detection issue for 64 bit

### DIFF
--- a/lib/chef/knife/bootstrap/windows-chef-client-msi.erb
+++ b/lib/chef/knife/bootstrap/windows-chef-client-msi.erb
@@ -91,18 +91,15 @@ goto Version6.2
   @set MACHINE_ARCH=<%= knife_config[:architecture] %>
 
   <% if knife_config[:architecture] == "x86_64" %>
-    IF "%PROCESSOR_ARCHITECTURE%"=="x86" (
+      IF "%PROCESSOR_ARCHITECTURE%"=="x86" IF not defined PROCESSOR_ARCHITEW6432 (
       echo You specified bootstrap_architecture as x86_64 but the target machine is i386. A 64 bit program cannot run on a 32 bit machine. > "&2"
       echo Exiting without bootstrapping. > "&2"
       exit /b 1
     )
   <% end %>
 <% else %>
-  IF "%PROCESSOR_ARCHITECTURE%"=="x86" (
-  @set MACHINE_ARCH=i686
-  ) ELSE (
   @set MACHINE_ARCH=x86_64
-  )
+  IF "%PROCESSOR_ARCHITECTURE%"=="x86" IF not defined PROCESSOR_ARCHITEW6432 @set MACHINE_ARCH=i686
 <% end %>
 goto install
 


### PR DESCRIPTION
During knife windows bootstrapping of windows 64 bit machine using `ssh` protocol, the code is not able to determine the  architecture properly, `PROCESSOR_ARCHITECTURE` value returns `x86(32bit)` instead of `AMD64(64 bit)`.
The behaviour is due to WOW64, added more validation to detect the architecture properly.

Following are values for various scenarios:- 

        Environment Variable      	 | 32bit Native	| 64bit Native	|  WOW64
        PROCESSOR_ARCHITECTURE   	 |   x86        |    AMD64      |  x86
        PROCESSOR_ARCHITEW6432     	 | undefined    |   undefined	|  AMD64

Reference:- https://blogs.msdn.microsoft.com/joshwil/2004/03/11/as-promised-what-is-the-wow64-and-what-does-it-mean-to-managed-apps-that-you-run-on-64bit-machines/
