### PR TITLE
Cleanup knife-windows configuration options

### DIFF
--- a/lib/chef/knife/knife_windows_base.rb
+++ b/lib/chef/knife/knife_windows_base.rb
@@ -20,13 +20,26 @@ class Chef
   class Knife
     module KnifeWindowsBase
 
+      # E.G. for config value 'attribute', look for :attribute
+      # and then :winrm_attribute,
       def locate_config_value(key)
-        key = key.to_sym
-        value = config[key] || Chef::Config[:knife][key] || default_config[key]
-        Chef::Log.debug("Looking for key #{key} and found value #{value}")
+        key    = key.to_s
+        symbol = key.to_sym
+        # look for config key as stated
+        if not value = config[symbol] || Chef::Config[:knife][symbol] || default_config[symbol]
+          if key =~ /^winrm_/
+            # if stated key starts with winrm_, remove it and look for that
+            symbol = key.gsub(/^winrm_/, '').to_sym
+          else
+            # look for key with 'winrm_' prepended
+            symbol = "winrm_#{key}".to_sym
+          end
+          Chef::Log.debug("Couldn't find value for config key: \"#{key}\", trying \"#{symbol.to_s}\"")
+          value = config[symbol] || Chef::Config[:knife][symbol] || default_config[symbol]
+        end
+        Chef::Log.debug("Config: #{symbol.to_s}: #{value ? value : ''}")
         value
       end
-
     end
   end
 end

--- a/lib/chef/knife/winrm_knife_base.rb
+++ b/lib/chef/knife/winrm_knife_base.rb
@@ -72,7 +72,7 @@ class Chef
                      q = Chef::Search::Query.new
                      @action_nodes = q.search(:node, @name_args[0])[0]
                      @action_nodes.each do |item|
-                       i = extract_nested_value(item, config[:attribute])
+                       i = extract_nested_value(item, config[:winrm_attribute])
                        r.push(i) unless i.nil?
                      end
                      r
@@ -83,8 +83,8 @@ class Chef
                 ui.fatal("No nodes returned from search!")
               else
                 ui.fatal("#{@action_nodes.length} #{@action_nodes.length > 1 ? "nodes":"node"} found, " +
-                         "but does not have the required attribute (#{config[:attribute]}) to establish the connection. " +
-                         "Try setting another attribute to open the connection using --attribute.")
+                         "but does not have the required attribute (#{config[:winrm_attribute]}) to establish the connection. " +
+                         "Try setting another attribute to open the connection using --winrm-attribute.")
               end
               exit 10
             end

--- a/lib/chef/knife/winrm_shared_options.rb
+++ b/lib/chef/knife/winrm_shared_options.rb
@@ -34,9 +34,9 @@ class Chef
             :description => "QUERY is a space separated list of servers",
             :default => false
 
-          option :attribute,
-            :short => "-a ATTR",
-            :long => "--attribute ATTR",
+          option :winrm_attribute,
+            :short => "-g ATTR",
+            :long => "--winrm-attribute ATTR",
             :description => "The attribute to use for opening the connection - default is fqdn",
             :default => "fqdn"
         end

--- a/spec/unit/knife/bootstrap_options_spec.rb
+++ b/spec/unit/knife/bootstrap_options_spec.rb
@@ -103,7 +103,7 @@ expected: #{expected}
 
     # win_ignore: Options in windows that aren't relevant to core.
     let(:win_ignore) { [
-      :attribute,
+      :winrm_attribute,
       :auth_timeout,
       :ca_trust_file,
       :install_as_service,

--- a/spec/unit/knife/winrm_spec.rb
+++ b/spec/unit/knife/winrm_spec.rb
@@ -29,7 +29,7 @@ describe Chef::Knife::Winrm do
   describe "#resolve_target_nodes" do
     before do
       @knife = Chef::Knife::Winrm.new
-      @knife.config[:attribute] = "fqdn"
+      @knife.config[:winrm_attribute] = "fqdn"
       @node_foo = Chef::Node.new
       @node_foo.automatic_attrs[:fqdn] = "foo.example.org"
       @node_foo.automatic_attrs[:ipaddress] = "10.0.0.1"
@@ -67,7 +67,7 @@ describe Chef::Knife::Winrm do
       end
 
       it "uses the nested attributes (KNIFE-276)" do
-        @knife.config[:attribute] = "ec2.public_hostname"
+        @knife.config[:winrm_attribute] = "ec2.public_hostname"
         @knife.configure_chef
         @knife.resolve_target_nodes
       end


### PR DESCRIPTION
- :atribute -> :winrm_attribute
- fallback to '(winrm_)<attr>' in #locate_config_value

```
 rspec

<snip>

Finished in 0.77848 seconds (files took 2.59 seconds to load)
118 examples, 0 failures

 knife --version
Chef: 12.13.37
```

/cc @adamedx 
