### PR TITLE
Use winrm v2 and allow users to pass a shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ Or force a chef run:
 
 This subcommand operates in a manner similar to [knife ssh](https://docs.chef.io/knife_ssh.html)...just leveraging the WinRM protocol for communication. It also includes `knife ssh`'s "[interactive session mode](https://docs.chef.io/knife_ssh.html#options)"
 
+#### winrm-shell
+
+By default, `knife winrm` runs in a `cmd.exe` shell. You can use the `--winrm-shell` argument to change the shell to `powershell` or `elevated`. An elevated shell is similar to the `powershell` shell but the powershell command is executed from a scheduled task using a local identity. This may be desirable for some operations such as running `chef-client` to converge recipes that work with windows updates, install sql server, etc.
+
 ### knife bootstrap windows winrm
 
 Performs a Chef Bootstrap (via the WinRM protocol) on the target node. The goal of the bootstrap is to get Chef installed on the target system so it can run Chef Client with a Chef Server. The main assumption is a baseline OS installation exists. It is primarily intended for Chef Client systems that talk to a Chef server.

--- a/knife-windows.gemspec
+++ b/knife-windows.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.description = s.summary
 
   s.required_ruby_version	= ">= 1.9.1"
-  s.add_dependency "winrm", "~> 2.0"
+  s.add_dependency "winrm-elevated", "~> 1.0"
 
   s.add_development_dependency 'pry'
 

--- a/knife-windows.gemspec
+++ b/knife-windows.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.description = s.summary
 
   s.required_ruby_version	= ">= 1.9.1"
-  s.add_dependency "winrm", "~> 1.7"
+  s.add_dependency "winrm", "~> 2.0"
 
   s.add_development_dependency 'pry'
 

--- a/lib/chef/knife/bootstrap_windows_winrm.rb
+++ b/lib/chef/knife/bootstrap_windows_winrm.rb
@@ -49,6 +49,11 @@ class Chef
           end
         end
 
+        unless locate_config_value(:winrm_shell) == :cmd
+          ui.warn("The cmd shell is the only valid winrm-shell for 'knife bootstrap windows winrm'. Switching to the cmd shell.")
+          config[:winrm_shell] = :cmd
+        end
+
         config[:manual] = true
         configure_session
 

--- a/lib/chef/knife/winrm_base.rb
+++ b/lib/chef/knife/winrm_base.rb
@@ -51,6 +51,12 @@ class Chef
             :description => "The WinRM password",
             :proc => Proc.new { |key| Chef::Config[:knife][:winrm_password] = key }
 
+          option :winrm_shell,
+            :long => "--winrm-shell SHELL",
+            :description => "The WinRM shell type. Valid choices are [cmd, powershell, elevated]",
+            :default => :cmd,
+            :proc => Proc.new { |shell| shell.to_sym }
+
           option :winrm_transport,
             :short => "-t TRANSPORT",
             :long => "--winrm-transport TRANSPORT",

--- a/lib/chef/knife/winrm_base.rb
+++ b/lib/chef/knife/winrm_base.rb
@@ -53,7 +53,7 @@ class Chef
 
           option :winrm_shell,
             :long => "--winrm-shell SHELL",
-            :description => "The WinRM shell type. Valid choices are [cmd, powershell, elevated]",
+            :description => "The WinRM shell type. Valid choices are [cmd, powershell, elevated]. 'elevated' runs powershell in a scheduled task",
             :default => :cmd,
             :proc => Proc.new { |shell| shell.to_sym }
 

--- a/lib/chef/knife/winrm_knife_base.rb
+++ b/lib/chef/knife/winrm_knife_base.rb
@@ -201,7 +201,8 @@ class Chef
               disable_sspi: resolve_winrm_disable_sspi,
               transport: resolve_winrm_transport,
               no_ssl_peer_verification: resolve_no_ssl_peer_verification,
-              ssl_peer_fingerprint: resolve_ssl_peer_fingerprint
+              ssl_peer_fingerprint: resolve_ssl_peer_fingerprint,
+              shell: locate_config_value(:winrm_shell)
             }
 
             if @session_opts[:user] and (not @session_opts[:password])

--- a/spec/dummy_winrm_connection.rb
+++ b/spec/dummy_winrm_connection.rb
@@ -8,15 +8,14 @@ module Dummy
     end
   end
 
-  class WinRMService
-    attr_reader :xfer
+  class Connection
+    attr_reader :transport
     attr_accessor :logger
 
     def initialize
-      @xfer = WinRMTransport.new
+      @transport = WinRMTransport.new
     end
 
-    def set_timeout(timeout); end
-    def create_executor; end
+    def shell; end
   end
 end

--- a/spec/functional/bootstrap_download_spec.rb
+++ b/spec/functional/bootstrap_download_spec.rb
@@ -17,6 +17,7 @@
 # limitations under the License.
 #
 
+require 'dummy_winrm_connection'
 require 'spec_helper'
 require 'tmpdir'
 
@@ -132,6 +133,7 @@ describe 'Knife::Windows::Core msi download functionality for knife Windows winr
       allow(File).to receive(:exist?).with(File.expand_path(Chef::Config[:validation_key])).and_return(true)
     end
 
+    allow(WinRM::Connection).to receive(:new).and_return(Dummy::Connection.new)
     allow(winrm_bootstrapper).to receive(:wait_for_remote_response)
     allow(winrm_bootstrapper).to receive(:validate_options!)
     allow(winrm_bootstrapper.ui).to receive(:ask).and_return(nil)

--- a/spec/unit/knife/bootstrap_windows_winrm_spec.rb
+++ b/spec/unit/knife/bootstrap_windows_winrm_spec.rb
@@ -49,7 +49,7 @@ describe Chef::Knife::BootstrapWindowsWinrm do
   let(:session) { Chef::Knife::WinrmSession.new(session_opts) }
   let(:arch_session_result) {
     o = WinRM::Output.new
-    o[:data] << {stdout: "X86\r\n"}
+    o << {stdout: "X86\r\n"}
     o
   }
   let(:arch_session_results) { [arch_session_result] }

--- a/spec/unit/knife/winrm_session_spec.rb
+++ b/spec/unit/knife/winrm_session_spec.rb
@@ -17,19 +17,18 @@
 #
 
 require 'spec_helper'
-require 'dummy_winrm_service'
+require 'dummy_winrm_connection'
 
 Chef::Knife::Winrm.load_deps
 
 
 describe Chef::Knife::WinrmSession do
-  let(:winrm_service) { Dummy::WinRMService.new }
+  let(:winrm_connection) { Dummy::Connection.new }
   let(:options) { { transport: :plaintext } }
 
   before do
     @original_config = Chef::Config.hash_dup
-    allow(WinRM::WinRMWebService).to receive(:new).and_return(winrm_service)
-    allow(winrm_service).to receive(:set_timeout)
+    allow(WinRM::Connection).to receive(:new).and_return(winrm_connection)
   end
 
   after do
@@ -54,7 +53,7 @@ describe Chef::Knife::WinrmSession do
 
       it "sets the ssl policy on the winrm client" do
         expect(Chef::HTTP::DefaultSSLPolicy).to receive(:new)
-          .with(winrm_service.xfer.httpcli.ssl_config)
+          .with(winrm_connection.transport.httpcli.ssl_config)
           .and_return(ssl_policy)
         expect(ssl_policy).to receive(:set_custom_certs)
         subject
@@ -65,7 +64,7 @@ describe Chef::Knife::WinrmSession do
 
   describe "#relay_command" do
     it "run command and display commands output" do
-      expect(winrm_service).to receive(:create_executor).ordered.and_return({})
+      expect(winrm_connection).to receive(:shell)
       subject.relay_command("cmd.exe echo 'hi'")
     end
   end

--- a/spec/unit/knife/winrm_spec.rb
+++ b/spec/unit/knife/winrm_spec.rb
@@ -24,13 +24,11 @@ Chef::Knife::Winrm.load_deps
 describe Chef::Knife::Winrm do
   before(:all) do
     Chef::Config.reset
-    @original_config = Chef::Config.hash_dup
-    @original_knife_config = Chef::Config[:knife].nil? ? nil : Chef::Config[:knife].dup
+    @original_config = Chef::Config.save
   end
 
   after do
-    Chef::Config.configuration = @original_config
-    Chef::Config[:knife] = @original_knife_config if @original_knife_config
+    Chef::Config.restore(@original_config)
   end
 
   describe "#resolve_target_nodes" do

--- a/spec/unit/knife/winrm_spec.rb
+++ b/spec/unit/knife/winrm_spec.rb
@@ -17,7 +17,7 @@
 #
 
 require 'spec_helper'
-require 'dummy_winrm_service'
+require 'dummy_winrm_connection'
 
 Chef::Knife::Winrm.load_deps
 
@@ -97,7 +97,7 @@ describe Chef::Knife::Winrm do
       ]
     end
     let(:winrm_session) { double('winrm_session') }
-    let(:winrm_service) { Dummy::WinRMService.new }
+    let(:winrm_connection) { Dummy::Connection.new }
 
     subject { Chef::Knife::Winrm.new(knife_args) }
 
@@ -194,7 +194,7 @@ describe Chef::Knife::Winrm do
         ]) }
 
         it "sets the transport to kerberos" do
-          expect(WinRM::WinRMWebService).to receive(:new).with('http://localhost:5985/wsman', :kerberos, anything).and_return(winrm_service)
+          expect(WinRM::Connection).to receive(:new).with(hash_including(:transport => :kerberos)).and_return(winrm_connection)
           winrm_command_http.configure_chef
           winrm_command_http.configure_session
         end
@@ -211,7 +211,7 @@ describe Chef::Knife::Winrm do
 
         it "sets the transport to plaintext" do
           winrm_command_http.config[:kerberos_realm] = nil
-          expect(WinRM::WinRMWebService).to receive(:new).with('http://localhost:5985/wsman', :plaintext, anything).and_return(winrm_service)
+          expect(WinRM::Connection).to receive(:new).with(hash_including(:transport => :plaintext)).and_return(winrm_connection)
           winrm_command_http.configure_chef
           winrm_command_http.configure_session
         end
@@ -241,15 +241,14 @@ describe Chef::Knife::Winrm do
 
         it "defaults to the http uri scheme" do
           expect(Chef::Knife::WinrmSession).to receive(:new).with(hash_including(:transport => :plaintext)).and_call_original
-          expect(WinRM::WinRMWebService).to receive(:new).with('http://localhost:5985/wsman', anything, anything).and_return(winrm_service)
+          expect(WinRM::Connection).to receive(:new).with(hash_including(:endpoint => 'http://localhost:5985/wsman')).and_return(winrm_connection)
           winrm_command_http.configure_chef
           winrm_command_http.configure_session
         end
 
         it "sets the operation timeout and verifes default" do
-          expect(Chef::Knife::WinrmSession).to receive(:new).with(hash_including(:transport => :plaintext)).and_call_original
-          expect(WinRM::WinRMWebService).to receive(:new).with('http://localhost:5985/wsman', anything, anything).and_return(winrm_service)
-          expect(winrm_service).to receive(:set_timeout).with(1800)
+          expect(Chef::Knife::WinrmSession).to receive(:new).with(hash_including(:operation_timeout => 1800)).and_call_original
+          expect(WinRM::Connection).to receive(:new).with(hash_including(:operation_timeout => 1800)).and_return(winrm_connection)
           winrm_command_http.configure_chef
           winrm_command_http.configure_session
         end
@@ -257,7 +256,7 @@ describe Chef::Knife::Winrm do
         it "sets the user specified winrm port" do
           Chef::Config[:knife] = {winrm_port: "5988"}
           expect(Chef::Knife::WinrmSession).to receive(:new).with(hash_including(:transport => :plaintext)).and_call_original
-          expect(WinRM::WinRMWebService).to receive(:new).with('http://localhost:5988/wsman', anything, anything).and_return(winrm_service)
+          expect(WinRM::Connection).to receive(:new).with(hash_including(:transport => :plaintext)).and_return(winrm_connection)
           winrm_command_http.configure_chef
           winrm_command_http.configure_session
         end
@@ -265,9 +264,8 @@ describe Chef::Knife::Winrm do
         let(:winrm_command_timeout) { Chef::Knife::Winrm.new(['-m', 'localhost', '-x', 'testuser', '-P', 'testpassword', '--winrm-authentication-protocol', 'basic', '--session-timeout', '10', 'echo helloworld']) }
 
         it "sets operation timeout and verify 10 Minute timeout" do
-          expect(Chef::Knife::WinrmSession).to receive(:new).with(hash_including(:transport => :plaintext)).and_call_original
-          expect(WinRM::WinRMWebService).to receive(:new).with('http://localhost:5985/wsman', anything, anything).and_return(winrm_service)
-          expect(winrm_service).to receive(:set_timeout).with(600)
+          expect(Chef::Knife::WinrmSession).to receive(:new).with(hash_including(:operation_timeout => 600)).and_call_original
+          expect(WinRM::Connection).to receive(:new).with(hash_including(:operation_timeout => 600)).and_return(winrm_connection)
           winrm_command_timeout.configure_chef
           winrm_command_timeout.configure_session
         end
@@ -277,7 +275,7 @@ describe Chef::Knife::Winrm do
         it "uses the https uri scheme if the ssl transport is specified" do
           Chef::Config[:knife] = {:winrm_transport => 'ssl'}
           expect(Chef::Knife::WinrmSession).to receive(:new).with(hash_including(:transport => :ssl)).and_call_original
-          expect(WinRM::WinRMWebService).to receive(:new).with('https://localhost:5986/wsman', anything, anything).and_return(winrm_service)
+          expect(WinRM::Connection).to receive(:new).with(hash_including(:endpoint => 'https://localhost:5986/wsman')).and_return(winrm_connection)
           winrm_command_https.configure_chef
           winrm_command_https.configure_session
         end
@@ -285,14 +283,14 @@ describe Chef::Knife::Winrm do
         it "uses the winrm port '5986' by default for ssl transport" do
           Chef::Config[:knife] = {:winrm_transport => 'ssl'}
           expect(Chef::Knife::WinrmSession).to receive(:new).with(hash_including(:transport => :ssl)).and_call_original
-          expect(WinRM::WinRMWebService).to receive(:new).with('https://localhost:5986/wsman', anything, anything).and_return(winrm_service)
+          expect(WinRM::Connection).to receive(:new).with(hash_including(:endpoint => 'https://localhost:5986/wsman')).and_return(winrm_connection)
           winrm_command_https.configure_chef
           winrm_command_https.configure_session
         end
 
         it "defaults to validating the server when the ssl transport is used" do
           expect(Chef::Knife::WinrmSession).to receive(:new).with(hash_including(:transport => :ssl)).and_call_original
-          expect(WinRM::WinRMWebService).to receive(:new).with(anything, anything, hash_including(:no_ssl_peer_verification => false)).and_return(winrm_service)
+          expect(WinRM::Connection).to receive(:new).with(hash_including(:no_ssl_peer_verification => false)).and_return(winrm_connection)
           winrm_command_https.configure_chef
           winrm_command_https.configure_session
         end
@@ -301,7 +299,7 @@ describe Chef::Knife::Winrm do
 
         it "validates the server when the ssl transport is used and the :winrm_ssl_verify_mode option is not configured to :verify_none" do
           expect(Chef::Knife::WinrmSession).to receive(:new).with(hash_including(:transport => :ssl)).and_call_original
-          expect(WinRM::WinRMWebService).to receive(:new).with(anything, anything, hash_including(:no_ssl_peer_verification => false)).and_return(winrm_service)
+          expect(WinRM::Connection).to receive(:new).with(hash_including(:no_ssl_peer_verification => false)).and_return(winrm_connection)
           winrm_command_verify_peer.configure_chef
           winrm_command_verify_peer.configure_session
         end
@@ -313,14 +311,14 @@ describe Chef::Knife::Winrm do
 
           it "does not validate the server when the ssl transport is used and the :winrm_ssl_verify_mode option is set to :verify_none" do
             expect(Chef::Knife::WinrmSession).to receive(:new).with(hash_including(:transport => :ssl)).and_call_original
-            expect(WinRM::WinRMWebService).to receive(:new).with(anything, anything, hash_including(:no_ssl_peer_verification => true)).and_return(winrm_service)
+            expect(WinRM::Connection).to receive(:new).with(hash_including(:no_ssl_peer_verification => true)).and_return(winrm_connection)
             subject.configure_chef
             subject.configure_session
           end
 
           it "prints warning output when the :winrm_ssl_verify_mode set to :verify_none to disable server validation" do
             expect(Chef::Knife::WinrmSession).to receive(:new).with(hash_including(:transport => :ssl)).and_call_original
-            expect(WinRM::WinRMWebService).to receive(:new).with(anything, anything, hash_including(:no_ssl_peer_verification => true)).and_return(winrm_service)
+            expect(WinRM::Connection).to receive(:new).with(hash_including(:no_ssl_peer_verification => true)).and_return(winrm_connection)
             expect(subject).to receive(:warn_no_ssl_peer_verification)
 
             subject.configure_chef
@@ -332,7 +330,7 @@ describe Chef::Knife::Winrm do
 
             it "does not print warning re ssl server validation" do
               expect(Chef::Knife::WinrmSession).to receive(:new).with(hash_including(:transport => :plaintext)).and_call_original
-              expect(WinRM::WinRMWebService).to receive(:new).and_return(winrm_service)
+              expect(WinRM::Connection).to receive(:new).and_return(winrm_connection)
               expect(subject).to_not receive(:warn_no_ssl_peer_verification)
 
               subject.configure_chef
@@ -345,7 +343,7 @@ describe Chef::Knife::Winrm do
 
         it "validates the server when the ssl transport is used and the :ca_trust_file option is specified even if the :winrm_ssl_verify_mode option is set to :verify_none" do
           expect(Chef::Knife::WinrmSession).to receive(:new).with(hash_including(:transport => :ssl)).and_call_original
-          expect(WinRM::WinRMWebService).to receive(:new).with(anything, anything, hash_including(:no_ssl_peer_verification => false)).and_return(winrm_service)
+          expect(WinRM::Connection).to receive(:new).with(hash_including(:no_ssl_peer_verification => false)).and_return(winrm_connection)
           winrm_command_ca_trust.configure_chef
           winrm_command_ca_trust.configure_session
         end


### PR DESCRIPTION
This uses the just released winrm v2 gems and allows users to specify a winrm shell. This can be `cmd`, `powershell`, or `elevated`.  `cmd` is the default. `elevated` will run commands via a powershell based scheduled task.