### PR TITLE
Allow a custom codepage to be specified and passed to the cmd shell

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: ruby
 
 rvm:
   - 2.1
-  - 2.2
+  - 2.3
 
 before_install:
   - gem install bundler

--- a/Gemfile
+++ b/Gemfile
@@ -10,5 +10,4 @@ group :test do
   gem "ruby-wmi"
   gem "httpclient"
   gem 'rake'
-  gem "rack", "< 2.0" # 2.0 requires Ruby 2.2+
 end

--- a/README.md
+++ b/README.md
@@ -217,6 +217,10 @@ of these authentication transports are outside of the scope of this
 README but details can be found on the
 [WinRM configuration guide](http://msdn.microsoft.com/en-us/library/aa384372\(v=vs.85\).aspx).
 
+### Working with legacy Windows versions
+
+If you are attempting to use `knife winrm` or `knife bootstrap windows winrm` with a version of windows that is older than server 2008 R2 or older than Windows 7 then you may need to alter the default UTF-8 codepage (65001) using the `--winrm-codepage` argument. You can use the codepage native to your locale but `437` is a safe codepage for older Windows versions.
+
 #### Configure SSL on a Windows node
 
 WinRM supports use of SSL to provide privacy and integrity of

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,10 +11,10 @@ environment:
     - ruby_version: "20"
       chef_version: "< 12"
 
-    - ruby_version: "21"
+    - ruby_version: "23"
       chef_version: "~> 12.0"
 
-    - ruby_version: "21"
+    - ruby_version: "23"
       chef_version: "master"
 
 clone_folder: c:\projects\knife-windows

--- a/knife-windows.gemspec
+++ b/knife-windows.gemspec
@@ -14,6 +14,7 @@ Gem::Specification.new do |s|
   s.description = s.summary
 
   s.required_ruby_version	= ">= 1.9.1"
+  s.add_dependency "winrm", "~> 2.1"
   s.add_dependency "winrm-elevated", "~> 1.0"
 
   s.add_development_dependency 'pry'

--- a/lib/chef/knife/winrm_base.rb
+++ b/lib/chef/knife/winrm_base.rb
@@ -116,6 +116,11 @@ class Chef
             :long => "--session-timeout Minutes",
             :description => "The timeout for the client for the maximum length of the WinRM session",
             :default => 30
+
+          option :winrm_codepage,
+            :long => "--winrm-codepage Codepage",
+            :description => "The codepage to use for the winrm cmd shell",
+            :default => 65001
         end
       end
     end

--- a/lib/chef/knife/winrm_knife_base.rb
+++ b/lib/chef/knife/winrm_knife_base.rb
@@ -202,7 +202,8 @@ class Chef
               transport: resolve_winrm_transport,
               no_ssl_peer_verification: resolve_no_ssl_peer_verification,
               ssl_peer_fingerprint: resolve_ssl_peer_fingerprint,
-              shell: locate_config_value(:winrm_shell)
+              shell: locate_config_value(:winrm_shell),
+              codepage: locate_config_value(:winrm_codepage)
             }
 
             if @session_opts[:user] and (not @session_opts[:password])

--- a/lib/chef/knife/winrm_session.rb
+++ b/lib/chef/knife/winrm_session.rb
@@ -31,7 +31,8 @@ class Chef
         @host = options[:host]
         @port = options[:port]
         @user = options[:user]
-        @shell = options[:shell]
+        @shell_args = [ options[:shell] ]
+        @shell_args << { codepage: options[:codepage] } if options[:shell] == :cmd
         url = "#{options[:host]}:#{options[:port]}/wsman"
         scheme = options[:transport] == :ssl ? 'https' : 'http'
         @endpoint = "#{scheme}://#{url}"
@@ -63,7 +64,7 @@ class Chef
 
       def relay_command(command)
         session_result = WinRM::Output.new
-        @winrm_session.shell(@shell) do |shell|
+        @winrm_session.shell(*@shell_args) do |shell|
           shell.username = @user.split("\\").last if shell.respond_to?(:username)
           session_result = shell.run(command) do |stdout, stderr|
             print_data(@host, stdout) if stdout

--- a/spec/unit/knife/winrm_session_spec.rb
+++ b/spec/unit/knife/winrm_session_spec.rb
@@ -67,5 +67,29 @@ describe Chef::Knife::WinrmSession do
       expect(winrm_connection).to receive(:shell)
       subject.relay_command("cmd.exe echo 'hi'")
     end
+
+    context "cmd shell" do
+      before do
+        options[:shell] = :cmd
+        options[:codepage] = 65001
+      end
+
+      it "creates shell and sends codepage" do
+        expect(winrm_connection).to receive(:shell).with(:cmd, hash_including(codepage: 65001))
+        subject.relay_command("cmd.exe echo 'hi'")
+      end
+    end
+
+    context "powershell shell" do
+      before do
+        options[:shell] = :powershell
+        options[:codepage] = 65001
+      end
+
+      it "does not send codepage to shell" do
+        expect(winrm_connection).to receive(:shell).with(:powershell)
+        subject.relay_command("cmd.exe echo 'hi'")
+      end
+    end
   end
 end


### PR DESCRIPTION
Older Windows versions prior to 2008R2 fail on the default UTF-8 codepage (65001). This PR allows users to pass a custom codepage. Typically for en-US users, `437` should be used for 2008 R1. This PR levereges the newly released WinRM 2.1.0 which exposes codepage and other shell options for the `:cmd` based shell.