### PR TITLE
Added --bootstrap-url argument to add support for leveraging mixlib-i…

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,19 @@ Currently (March 2016) the `stable` channel of omnibus (where downloads using th
 
 #### Using a custom install URL
 
-By default, the bootstrap command tries to download the latest `chef-client` installer from the Internet.  This may be a problem in the enterprise, for example if your node is behind a proxy or firewall.  In that case, you can specify a custom install URL with the `--msi-url` option.
+By default, the bootstrap command tries to download the latest `chef-client` installer from the Internet.  This may be a problem in the enterprise, for example if your node is behind a proxy or firewall.  
+
+There are two options available to get around this.
+
+You can specify a custom install URL with the `--msi-url` option, or you can
+point to a mixlib-install script using the `--bootstrap-url` option.
+
+> See: https://omnitruck.chef.io/chef/install.ps1
+
+This will maintain the platform architecture detection functionality while still
+allowing you to source the installer internally.
+
+*`--bootstrap-url` will honor the `--bootstrap-version` as well as the `bootstrap_architecture` knife config setting.*
 
 ### knife wsman test
 

--- a/lib/chef/knife/bootstrap/windows-chef-client-msi.erb
+++ b/lib/chef/knife/bootstrap/windows-chef-client-msi.erb
@@ -32,6 +32,25 @@
     @echo Existing directory found, skipping creation.
 )
 
+<% if @chef_config[:knife][:bootstrap_url] %>
+@rem This will pull in the install.ps1 from mixlib-install
+@rem using the provided URL, this allows you to default it
+@rem to the public copy hosted on chef.io or your own internal
+@rem instance.
+@rem
+@rem When this is used it will ignore the following conflicting parameters
+@rem * chef_config[:knife][:bootstrap_install_command]
+@rem * chef_config[:knife][:msi_url]
+
+> <%= bootstrap_directory %>\bootstrap.ps1 (
+  <%= bootstrap_ps_content( @chef_config[:knife][:bootstrap_url], knife_config[:architecture], @chef_config[:knife][:bootstrap_version] ) %>
+)
+
+@echo Downloading and running install.ps1 to install chef
+@set bootstrap_exec=powershell.exe -ExecutionPolicy Unrestricted -InputFormat None -NoProfile -NonInteractive -File  <%= bootstrap_directory %>\bootstrap.ps1
+@call !bootstrap_exec!
+
+<% else %>
 > <%= bootstrap_directory %>\wget.vbs (
  <%= win_wget %>
 )
@@ -188,6 +207,10 @@ goto install
       del /f /q "%CHEF_CLIENT_MSI_LOG_PATH%"
     )
 
+@rem END chef_config.knife.bootstrap_install_command
+<% end %>
+
+@rem END chef_config.knife.bootstrap_url
 <% end %>
 
 @endlocal

--- a/lib/chef/knife/bootstrap_windows_base.rb
+++ b/lib/chef/knife/bootstrap_windows_base.rb
@@ -50,6 +50,11 @@ class Chef
             :long => "--prerelease",
             :description => "Install the pre-release chef gems"
 
+          option :bootstrap_url,
+            :long        => "--bootstrap-url URL",
+            :description => "URL to a custom installation script",
+            :proc        => Proc.new { |u| Chef::Config[:knife][:bootstrap_url] = u }
+
           option :bootstrap_version,
             :long => "--bootstrap-version VERSION",
             :description => "The version of Chef to install",

--- a/lib/chef/knife/core/windows_bootstrap_context.rb
+++ b/lib/chef/knife/core/windows_bootstrap_context.rb
@@ -268,6 +268,17 @@ WGET_PS
           escape_and_echo(win_wget_ps)
         end
 
+        def bootstrap_ps_content(bootstrap_url, machine_arch=nil, version=nil)
+          version_parameter = version.nil? ? '-version latest' : "-version #{version}"
+          arch_parameter = machine_arch.nil? ? '-architecture auto' : "-architecture #{machine_arch}"
+          bootstrap_content = <<-BOOTSTRAP 
+Invoke-Expression (new-object net.webclient).downloadstring('#{bootstrap_url}') 
+Install-Project -project chef -channel stable #{version_parameter} #{arch_parameter}
+BOOTSTRAP
+
+          escape_and_echo(bootstrap_content)
+        end
+
         def install_chef
           # The normal install command uses regular double quotes in
           # the install command, so request such a string from install_command


### PR DESCRIPTION
…nstall from an alternate source. updated documentation to reflect option. Changed the bootstrap_template_spec environment setup to reset the config options before each pass. Configuration changes were being retained between describe blocks causing tests to fail when the order they were run in changed.

Due to environmental constraints at my company, installers had to be sourced internally. I worked with our chef success team to set up an internal mirror of omnitruck and mixlib-install to be able to leverage install.sh and the installer determination of omnitruck. Use of the --msi-url option ended up being cumbersome while attempting to bootstrap several thousand windows servers of various versions and architectures, this change allowed me to leverage the install.ps1 that came along with the internal mixlib-install setup. I wanted to share it back in the event it was of benefit to anyone else.

Signed-off-by: josh-hetland <josh.hetland@gmail.com>