### PR TITLE
Add concurrency support to knife-windows

### DIFF
--- a/lib/chef/knife/bootstrap_windows_base.rb
+++ b/lib/chef/knife/bootstrap_windows_base.rb
@@ -330,20 +330,22 @@ class Chef
         # create a bootstrap.bat file on the node
         # we have to run the remote commands in 2047 char chunks
         create_bootstrap_bat_command do |command_chunk|
-          begin
-            render_command_result = run_command(command_chunk)
-            ui.error("Batch render command returned #{render_command_result}") if render_command_result != 0
-            render_command_result
-          rescue SystemExit => e
-            raise unless e.success?
+          render_command_result = run_command(command_chunk)
+          unless render_command_result == 0
+            ui.error("Batch render command returned #{render_command_result}")
+            exit render_command_result
           end
         end
 
         # execute the bootstrap.bat file
         bootstrap_command_result = run_command(bootstrap_command)
-        ui.error("Bootstrap command returned #{bootstrap_command_result}") if bootstrap_command_result != 0
+        unless bootstrap_command_result == 0
+          ui.error("Bootstrap command returned #{bootstrap_command_result}")
+          exit bootstrap_command_result
+        end
 
-        bootstrap_command_result
+        # exit 0
+        0
       end
 
       protected

--- a/lib/chef/knife/winrm.rb
+++ b/lib/chef/knife/winrm.rb
@@ -49,7 +49,12 @@ class Chef
         STDOUT.sync = STDERR.sync = true
 
         configure_session
-        execute_remote_command
+        exit_status = execute_remote_command
+        if exit_status != 0
+          exit exit_status
+        else
+          exit_status
+        end
       end
 
       def execute_remote_command

--- a/lib/chef/knife/winrm_session.rb
+++ b/lib/chef/knife/winrm_session.rb
@@ -73,6 +73,9 @@ class Chef
         end
         @exit_code = session_result.exitcode
         session_result
+      rescue WinRM::WinRMHTTPTransportError, WinRM::WinRMAuthorizationError => e
+        @exit_code = 401
+        raise e
       end
 
       private

--- a/lib/chef/knife/winrm_shared_options.rb
+++ b/lib/chef/knife/winrm_shared_options.rb
@@ -39,6 +39,13 @@ class Chef
             :long => "--attribute ATTR",
             :description => "The attribute to use for opening the connection - default is fqdn",
             :default => "fqdn"
+
+          option :concurrency,
+            :short => "-C NUM",
+            :long => "--concurrency NUM",
+            :description => "The number of allowed concurrent connections",
+            :default => 1,
+            :proc => lambda { |o| o.to_i }
         end
       end
 

--- a/spec/unit/knife/winrm_session_spec.rb
+++ b/spec/unit/knife/winrm_session_spec.rb
@@ -68,6 +68,12 @@ describe Chef::Knife::WinrmSession do
       subject.relay_command("cmd.exe echo 'hi'")
     end
 
+    it "exits with 401 if command execution raises a 401" do
+      expect(winrm_connection).to receive(:shell).and_raise(WinRM::WinRMHTTPTransportError.new('', '401'))
+      expect { subject.relay_command("cmd.exe echo 'hi'") }.to raise_error(WinRM::WinRMHTTPTransportError)
+      expect(subject.exit_code).to eql(401)
+    end
+
     context "cmd shell" do
       before do
         options[:shell] = :cmd

--- a/spec/unit/knife/winrm_spec.rb
+++ b/spec/unit/knife/winrm_spec.rb
@@ -422,12 +422,6 @@ describe Chef::Knife::Winrm do
       expect { @winrm.run_with_pretty_exceptions }.to raise_error(SystemExit) { |e| expect(e.status).to eq(100) }
     end
 
-    it "exits with 401 if command execution raises a 401 and suppress_auth_failure is set to true" do
-      @winrm.config[:suppress_auth_failure] = true
-      allow(session).to receive(:relay_command).and_raise(WinRM::WinRMHTTPTransportError.new('', '401'))
-      expect { @winrm.run_with_pretty_exceptions }.to raise_error(SystemExit) { |e| expect(e.status).to eq(401) }
-    end
-
     it "prints a hint on failure for negotiate authentication" do
       @winrm.config[:winrm_authentication_protocol] = "negotiate"
       @winrm.config[:winrm_transport] = "plaintext"


### PR DESCRIPTION
Until the native WinRM libraries support concurrent connections, add simple threading to handle parallel connections. 

Fixes #348

Signed-off-by: Tom Duffield <tom@chef.io>