### PR TITLE
adding client.rb rubygems_url if exists in knife.rb or Chef::Config[:…

### DIFF
--- a/lib/chef/knife/core/windows_bootstrap_context.rb
+++ b/lib/chef/knife/core/windows_bootstrap_context.rb
@@ -151,7 +151,7 @@ CONFIG
           # in client.rb for windows runs outside user profile C:\ProgramData
 
           if @chef_config[:rubygems_url]
-            client_rb << %Q{rubygems_url "#{@chef_config[:rubygems_url]}"\n}
+            client_rb << %Q{rubygems_url "#{@chef_config[:rubygems_url]}"}
           end
 
           escape_and_echo(client_rb)

--- a/lib/chef/knife/core/windows_bootstrap_context.rb
+++ b/lib/chef/knife/core/windows_bootstrap_context.rb
@@ -178,7 +178,7 @@ CONFIG
         def start_chef
           bootstrap_environment_option = bootstrap_environment.nil? ? '' : " -E #{bootstrap_environment}"
           start_chef = "SET \"PATH=%PATH%;C:\\ruby\\bin;C:\\opscode\\chef\\bin;C:\\opscode\\chef\\embedded\\bin\"\n"
-          start_chef << "chef-client -c c:/chef/client.rb -j c:/chef/first-boot.json#{bootstrap_environment_option}\n"
+          start_chef << "chef-client -c c:/chef/client.rb -j c:/chef/first-boot.json#{bootstrap_environment_option}"
         end
 
         def latest_current_windows_chef_version_query

--- a/lib/chef/knife/core/windows_bootstrap_context.rb
+++ b/lib/chef/knife/core/windows_bootstrap_context.rb
@@ -147,6 +147,13 @@ end
 CONFIG
           end
 
+          # For setting up Chef::Config[:rubygems_url]
+          # in client.rb for windows runs outside user profile C:\ProgramData
+
+          if @chef_config[:rubygems_url]
+            client_rb << %Q{rubygems_url "#{@chef_config[:rubygems_url]}"\n}
+          end
+
           escape_and_echo(client_rb)
         end
 

--- a/spec/assets/win_template_rendered_with_bootstrap_install_command.txt
+++ b/spec/assets/win_template_rendered_with_bootstrap_install_command.txt
@@ -208,7 +208,6 @@ echo.# Using default node name ^(fqdn^)
 echo.log_level        :info
 echo.log_location       STDOUT
 echo.rubygems_url "https://rubygems.org"
- 
 )
 
 > C:\chef\first-boot.json (

--- a/spec/assets/win_template_rendered_with_bootstrap_install_command.txt
+++ b/spec/assets/win_template_rendered_with_bootstrap_install_command.txt
@@ -207,7 +207,8 @@ echo.cache_options     ^({:path =^> "c:/chef/cache/checksums", :skip_expires =^>
 echo.# Using default node name ^(fqdn^)
 echo.log_level        :info
 echo.log_location       STDOUT
- 
+echo.rubygems_url "https://rubygems.org"
+
 ) 
 
 > C:\chef\first-boot.json ( 

--- a/spec/assets/win_template_rendered_with_bootstrap_install_command.txt
+++ b/spec/assets/win_template_rendered_with_bootstrap_install_command.txt
@@ -1,38 +1,38 @@
-@rem 
-@rem Author:: Seth Chisamore (<schisamo@opscode.com>) 
-@rem Copyright:: Copyright (c) 2011 Opscode, Inc. 
-@rem License:: Apache License, Version 2.0 
-@rem 
-@rem Licensed under the Apache License, Version 2.0 (the "License"); 
-@rem you may not use this file except in compliance with the License. 
-@rem You may obtain a copy of the License at 
-@rem 
-@rem     http://www.apache.org/licenses/LICENSE-2.0 
-@rem 
-@rem Unless required by applicable law or agreed to in writing, software 
-@rem distributed under the License is distributed on an "AS IS" BASIS, 
-@rem WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
-@rem See the License for the specific language governing permissions and 
-@rem limitations under the License. 
-@rem 
+@rem
+@rem Author:: Seth Chisamore (<schisamo@opscode.com>)
+@rem Copyright:: Copyright (c) 2011 Opscode, Inc.
+@rem License:: Apache License, Version 2.0
+@rem
+@rem Licensed under the Apache License, Version 2.0 (the "License");
+@rem you may not use this file except in compliance with the License.
+@rem You may obtain a copy of the License at
+@rem
+@rem     http://www.apache.org/licenses/LICENSE-2.0
+@rem
+@rem Unless required by applicable law or agreed to in writing, software
+@rem distributed under the License is distributed on an "AS IS" BASIS,
+@rem WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+@rem See the License for the specific language governing permissions and
+@rem limitations under the License.
+@rem
 
-@rem Use delayed environment expansion so that ERRORLEVEL can be evaluated with the 
-@rem !ERRORLEVEL! syntax which evaluates at execution of the line of script, not when 
-@rem the line is read. See help for the /E switch from cmd.exe /? . 
-@setlocal ENABLEDELAYEDEXPANSION 
+@rem Use delayed environment expansion so that ERRORLEVEL can be evaluated with the
+@rem !ERRORLEVEL! syntax which evaluates at execution of the line of script, not when
+@rem the line is read. See help for the /E switch from cmd.exe /? .
+@setlocal ENABLEDELAYEDEXPANSION
 
- 
 
-@set BOOTSTRAP_DIRECTORY=C:\chef 
-@echo Checking for existing directory "%BOOTSTRAP_DIRECTORY%"... 
-@if NOT EXIST %BOOTSTRAP_DIRECTORY% ( 
-    @echo Existing directory not found, creating. 
-    @mkdir %BOOTSTRAP_DIRECTORY% 
-) else ( 
-    @echo Existing directory found, skipping creation. 
-) 
 
-> C:\chef\wget.vbs ( 
+@set BOOTSTRAP_DIRECTORY=C:\chef
+@echo Checking for existing directory "%BOOTSTRAP_DIRECTORY%"...
+@if NOT EXIST %BOOTSTRAP_DIRECTORY% (
+    @echo Existing directory not found, creating.
+    @mkdir %BOOTSTRAP_DIRECTORY%
+) else (
+    @echo Existing directory found, skipping creation.
+)
+
+> C:\chef\wget.vbs (
  echo.url = WScript.Arguments.Named^("url"^)
 echo.path = WScript.Arguments.Named^("path"^)
 echo.proxy = null
@@ -95,10 +95,10 @@ echo.Set objADOStream = Nothing
 echo.End If
 echo.Set objXMLHTTP = Nothing
 echo.End If
- 
-) 
 
-> C:\chef\wget.ps1 ( 
+)
+
+> C:\chef\wget.ps1 (
  echo.param^(
 echo.   [String] $remoteUrl,
 echo.   [String] $localPath
@@ -113,92 +113,92 @@ echo.  $WebClient.Proxy = $WebProxy
 echo.}
 echo.
 echo.$webClient.DownloadFile^($remoteUrl, $localPath^);
- 
-) 
 
-@rem Determine the version and the architecture 
+)
 
-@FOR /F "usebackq tokens=1-8 delims=.[] " %%A IN (`ver`) DO ( 
-@set WinMajor=%%D 
-@set WinMinor=%%E 
-@set WinBuild=%%F 
-) 
+@rem Determine the version and the architecture
 
-@echo Detected Windows Version %WinMajor%.%WinMinor% Build %WinBuild% 
+@FOR /F "usebackq tokens=1-8 delims=.[] " %%A IN (`ver`) DO (
+@set WinMajor=%%D
+@set WinMinor=%%E
+@set WinBuild=%%F
+)
 
-@set LATEST_OS_VERSION_MAJOR=6 
-@set LATEST_OS_VERSION_MINOR=3 
+@echo Detected Windows Version %WinMajor%.%WinMinor% Build %WinBuild%
 
-@if /i %WinMajor% GTR %LATEST_OS_VERSION_MAJOR% goto VersionUnknown 
-@if /i %WinMajor% EQU %LATEST_OS_VERSION_MAJOR%  ( 
-  @if /i %WinMinor% GTR %LATEST_OS_VERSION_MINOR% goto VersionUnknown 
-) 
+@set LATEST_OS_VERSION_MAJOR=6
+@set LATEST_OS_VERSION_MINOR=3
 
-goto Version%WinMajor%.%WinMinor% 
+@if /i %WinMajor% GTR %LATEST_OS_VERSION_MAJOR% goto VersionUnknown
+@if /i %WinMajor% EQU %LATEST_OS_VERSION_MAJOR%  (
+  @if /i %WinMinor% GTR %LATEST_OS_VERSION_MINOR% goto VersionUnknown
+)
 
-:VersionUnknown 
-@rem If this is an unknown version of windows set the default 
-@set MACHINE_OS=2008r2 
-@echo Warning: Unknown version of Windows, assuming default of Windows %MACHINE_OS% 
-goto architecture_select 
+goto Version%WinMajor%.%WinMinor%
 
-:Version6.0 
-@set MACHINE_OS=2008 
-goto architecture_select 
+:VersionUnknown
+@rem If this is an unknown version of windows set the default
+@set MACHINE_OS=2008r2
+@echo Warning: Unknown version of Windows, assuming default of Windows %MACHINE_OS%
+goto architecture_select
 
-:Version5.2 
-@set MACHINE_OS=2003r2 
-goto architecture_select 
+:Version6.0
+@set MACHINE_OS=2008
+goto architecture_select
 
-:Version6.1 
-@set MACHINE_OS=2008r2 
-goto architecture_select 
+:Version5.2
+@set MACHINE_OS=2003r2
+goto architecture_select
 
-:Version6.2 
-@set MACHINE_OS=2012 
-goto architecture_select 
+:Version6.1
+@set MACHINE_OS=2008r2
+goto architecture_select
 
-@rem Currently Windows Server 2012 R2 is treated as equivalent to Windows Server 2012 
-:Version6.3 
-goto Version6.2 
+:Version6.2
+@set MACHINE_OS=2012
+goto architecture_select
 
-:architecture_select 
-goto Architecture%PROCESSOR_ARCHITEW6432% 
+@rem Currently Windows Server 2012 R2 is treated as equivalent to Windows Server 2012
+:Version6.3
+goto Version6.2
 
-:Architecture 
-goto Architecture%PROCESSOR_ARCHITECTURE% 
+:architecture_select
+goto Architecture%PROCESSOR_ARCHITEW6432%
 
-@rem If this is an unknown architecture set the default 
-@set MACHINE_ARCH=i686 
-goto install 
+:Architecture
+goto Architecture%PROCESSOR_ARCHITECTURE%
 
-:Architecturex86 
-@set MACHINE_ARCH=i686 
-goto install 
+@rem If this is an unknown architecture set the default
+@set MACHINE_ARCH=i686
+goto install
 
-:Architectureamd64 
-@set MACHINE_ARCH=x86_64 
-goto install 
+:Architecturex86
+@set MACHINE_ARCH=i686
+goto install
 
-:install 
-@rem If user has provided the custom installation command for chef-client then execute it 
-  chef-client -o recipe[cbk1::rec2] 
+:Architectureamd64
+@set MACHINE_ARCH=x86_64
+goto install
 
-@endlocal 
+:install
+@rem If user has provided the custom installation command for chef-client then execute it
+  chef-client -o recipe[cbk1::rec2]
 
-@echo off 
+@endlocal
 
-
-echo Writing validation key... 
+@echo off
 
 
-echo Validation key written. 
-@echo on 
+echo Writing validation key...
+
+
+echo Validation key written.
+@echo on
 
 
 
 
-> C:\chef\client.rb ( 
+> C:\chef\client.rb (
  echo.chef_server_url  "https://localhost:443"
 echo.validation_client_name "chef-validator"
 echo.file_cache_path   "c:/chef/cache"
@@ -208,14 +208,13 @@ echo.# Using default node name ^(fqdn^)
 echo.log_level        :info
 echo.log_location       STDOUT
 echo.rubygems_url "https://rubygems.org"
+ 
+)
 
-) 
+> C:\chef\first-boot.json (
+ echo.{"run_list":null}
+)
 
-> C:\chef\first-boot.json ( 
- echo.{"run_list":null} 
-) 
-
-@echo Starting chef to bootstrap the node... 
+@echo Starting chef to bootstrap the node...
 SET "PATH=%PATH%;C:\ruby\bin;C:\opscode\chef\bin;C:\opscode\chef\embedded\bin"
 chef-client -c c:/chef/client.rb -j c:/chef/first-boot.json
- 

--- a/spec/assets/win_template_rendered_with_bootstrap_install_command_on_12_5_client.txt
+++ b/spec/assets/win_template_rendered_with_bootstrap_install_command_on_12_5_client.txt
@@ -208,7 +208,6 @@ echo.# Using default node name ^(fqdn^)
 echo.log_level        :info
 echo.log_location       STDOUT
 echo.rubygems_url "https://rubygems.org"
- 
 )
 
 > C:\chef\first-boot.json (

--- a/spec/assets/win_template_rendered_with_bootstrap_install_command_on_12_5_client.txt
+++ b/spec/assets/win_template_rendered_with_bootstrap_install_command_on_12_5_client.txt
@@ -207,7 +207,8 @@ echo.cache_options     ^({:path =^> "c:/chef/cache/checksums", :skip_expires =^>
 echo.# Using default node name ^(fqdn^)
 echo.log_level        :info
 echo.log_location       STDOUT
- 
+echo.rubygems_url "https://rubygems.org"
+
 ) 
 
 > C:\chef\first-boot.json ( 

--- a/spec/assets/win_template_rendered_with_bootstrap_install_command_on_12_5_client.txt
+++ b/spec/assets/win_template_rendered_with_bootstrap_install_command_on_12_5_client.txt
@@ -1,38 +1,38 @@
-@rem 
-@rem Author:: Seth Chisamore (<schisamo@opscode.com>) 
-@rem Copyright:: Copyright (c) 2011 Opscode, Inc. 
-@rem License:: Apache License, Version 2.0 
-@rem 
-@rem Licensed under the Apache License, Version 2.0 (the "License"); 
-@rem you may not use this file except in compliance with the License. 
-@rem You may obtain a copy of the License at 
-@rem 
-@rem     http://www.apache.org/licenses/LICENSE-2.0 
-@rem 
-@rem Unless required by applicable law or agreed to in writing, software 
-@rem distributed under the License is distributed on an "AS IS" BASIS, 
-@rem WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
-@rem See the License for the specific language governing permissions and 
-@rem limitations under the License. 
-@rem 
+@rem
+@rem Author:: Seth Chisamore (<schisamo@opscode.com>)
+@rem Copyright:: Copyright (c) 2011 Opscode, Inc.
+@rem License:: Apache License, Version 2.0
+@rem
+@rem Licensed under the Apache License, Version 2.0 (the "License");
+@rem you may not use this file except in compliance with the License.
+@rem You may obtain a copy of the License at
+@rem
+@rem     http://www.apache.org/licenses/LICENSE-2.0
+@rem
+@rem Unless required by applicable law or agreed to in writing, software
+@rem distributed under the License is distributed on an "AS IS" BASIS,
+@rem WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+@rem See the License for the specific language governing permissions and
+@rem limitations under the License.
+@rem
 
-@rem Use delayed environment expansion so that ERRORLEVEL can be evaluated with the 
-@rem !ERRORLEVEL! syntax which evaluates at execution of the line of script, not when 
-@rem the line is read. See help for the /E switch from cmd.exe /? . 
-@setlocal ENABLEDELAYEDEXPANSION 
+@rem Use delayed environment expansion so that ERRORLEVEL can be evaluated with the
+@rem !ERRORLEVEL! syntax which evaluates at execution of the line of script, not when
+@rem the line is read. See help for the /E switch from cmd.exe /? .
+@setlocal ENABLEDELAYEDEXPANSION
 
- 
 
-@set BOOTSTRAP_DIRECTORY=C:\chef 
-@echo Checking for existing directory "%BOOTSTRAP_DIRECTORY%"... 
-@if NOT EXIST %BOOTSTRAP_DIRECTORY% ( 
-    @echo Existing directory not found, creating. 
-    @mkdir %BOOTSTRAP_DIRECTORY% 
-) else ( 
-    @echo Existing directory found, skipping creation. 
-) 
 
-> C:\chef\wget.vbs ( 
+@set BOOTSTRAP_DIRECTORY=C:\chef
+@echo Checking for existing directory "%BOOTSTRAP_DIRECTORY%"...
+@if NOT EXIST %BOOTSTRAP_DIRECTORY% (
+    @echo Existing directory not found, creating.
+    @mkdir %BOOTSTRAP_DIRECTORY%
+) else (
+    @echo Existing directory found, skipping creation.
+)
+
+> C:\chef\wget.vbs (
  echo.url = WScript.Arguments.Named^("url"^)
 echo.path = WScript.Arguments.Named^("path"^)
 echo.proxy = null
@@ -95,10 +95,10 @@ echo.Set objADOStream = Nothing
 echo.End If
 echo.Set objXMLHTTP = Nothing
 echo.End If
- 
-) 
 
-> C:\chef\wget.ps1 ( 
+)
+
+> C:\chef\wget.ps1 (
  echo.param^(
 echo.   [String] $remoteUrl,
 echo.   [String] $localPath
@@ -113,92 +113,92 @@ echo.  $WebClient.Proxy = $WebProxy
 echo.}
 echo.
 echo.$webClient.DownloadFile^($remoteUrl, $localPath^);
- 
-) 
 
-@rem Determine the version and the architecture 
+)
 
-@FOR /F "usebackq tokens=1-8 delims=.[] " %%A IN (`ver`) DO ( 
-@set WinMajor=%%D 
-@set WinMinor=%%E 
-@set WinBuild=%%F 
-) 
+@rem Determine the version and the architecture
 
-@echo Detected Windows Version %WinMajor%.%WinMinor% Build %WinBuild% 
+@FOR /F "usebackq tokens=1-8 delims=.[] " %%A IN (`ver`) DO (
+@set WinMajor=%%D
+@set WinMinor=%%E
+@set WinBuild=%%F
+)
 
-@set LATEST_OS_VERSION_MAJOR=6 
-@set LATEST_OS_VERSION_MINOR=3 
+@echo Detected Windows Version %WinMajor%.%WinMinor% Build %WinBuild%
 
-@if /i %WinMajor% GTR %LATEST_OS_VERSION_MAJOR% goto VersionUnknown 
-@if /i %WinMajor% EQU %LATEST_OS_VERSION_MAJOR%  ( 
-  @if /i %WinMinor% GTR %LATEST_OS_VERSION_MINOR% goto VersionUnknown 
-) 
+@set LATEST_OS_VERSION_MAJOR=6
+@set LATEST_OS_VERSION_MINOR=3
 
-goto Version%WinMajor%.%WinMinor% 
+@if /i %WinMajor% GTR %LATEST_OS_VERSION_MAJOR% goto VersionUnknown
+@if /i %WinMajor% EQU %LATEST_OS_VERSION_MAJOR%  (
+  @if /i %WinMinor% GTR %LATEST_OS_VERSION_MINOR% goto VersionUnknown
+)
 
-:VersionUnknown 
-@rem If this is an unknown version of windows set the default 
-@set MACHINE_OS=2008r2 
-@echo Warning: Unknown version of Windows, assuming default of Windows %MACHINE_OS% 
-goto architecture_select 
+goto Version%WinMajor%.%WinMinor%
 
-:Version6.0 
-@set MACHINE_OS=2008 
-goto architecture_select 
+:VersionUnknown
+@rem If this is an unknown version of windows set the default
+@set MACHINE_OS=2008r2
+@echo Warning: Unknown version of Windows, assuming default of Windows %MACHINE_OS%
+goto architecture_select
 
-:Version5.2 
-@set MACHINE_OS=2003r2 
-goto architecture_select 
+:Version6.0
+@set MACHINE_OS=2008
+goto architecture_select
 
-:Version6.1 
-@set MACHINE_OS=2008r2 
-goto architecture_select 
+:Version5.2
+@set MACHINE_OS=2003r2
+goto architecture_select
 
-:Version6.2 
-@set MACHINE_OS=2012 
-goto architecture_select 
+:Version6.1
+@set MACHINE_OS=2008r2
+goto architecture_select
 
-@rem Currently Windows Server 2012 R2 is treated as equivalent to Windows Server 2012 
-:Version6.3 
-goto Version6.2 
+:Version6.2
+@set MACHINE_OS=2012
+goto architecture_select
 
-:architecture_select 
-goto Architecture%PROCESSOR_ARCHITEW6432% 
+@rem Currently Windows Server 2012 R2 is treated as equivalent to Windows Server 2012
+:Version6.3
+goto Version6.2
 
-:Architecture 
-goto Architecture%PROCESSOR_ARCHITECTURE% 
+:architecture_select
+goto Architecture%PROCESSOR_ARCHITEW6432%
 
-@rem If this is an unknown architecture set the default 
-@set MACHINE_ARCH=i686 
-goto install 
+:Architecture
+goto Architecture%PROCESSOR_ARCHITECTURE%
 
-:Architecturex86 
-@set MACHINE_ARCH=i686 
-goto install 
+@rem If this is an unknown architecture set the default
+@set MACHINE_ARCH=i686
+goto install
 
-:Architectureamd64 
-@set MACHINE_ARCH=x86_64 
-goto install 
+:Architecturex86
+@set MACHINE_ARCH=i686
+goto install
 
-:install 
-@rem If user has provided the custom installation command for chef-client then execute it 
-  chef-client -o recipe[cbk1::rec2] 
+:Architectureamd64
+@set MACHINE_ARCH=x86_64
+goto install
 
-@endlocal 
+:install
+@rem If user has provided the custom installation command for chef-client then execute it
+  chef-client -o recipe[cbk1::rec2]
 
-@echo off 
+@endlocal
 
-
-echo Writing validation key... 
+@echo off
 
 
-echo Validation key written. 
-@echo on 
+echo Writing validation key...
+
+
+echo Validation key written.
+@echo on
 
 
 
 
-> C:\chef\client.rb ( 
+> C:\chef\client.rb (
  echo.chef_server_url  "https://localhost:443"
 echo.validation_client_name "chef-validator"
 echo.file_cache_path   "c:/chef/cache"
@@ -208,14 +208,13 @@ echo.# Using default node name ^(fqdn^)
 echo.log_level        :info
 echo.log_location       STDOUT
 echo.rubygems_url "https://rubygems.org"
+ 
+)
 
-) 
+> C:\chef\first-boot.json (
+ echo.{"run_list":null}
+)
 
-> C:\chef\first-boot.json ( 
- echo.{"run_list":null} 
-) 
-
-@echo Starting chef to bootstrap the node... 
+@echo Starting chef to bootstrap the node...
 SET "PATH=%PATH%;C:\ruby\bin;C:\opscode\chef\bin;C:\opscode\chef\embedded\bin"
 chef-client -c c:/chef/client.rb -j c:/chef/first-boot.json
- 

--- a/spec/assets/win_template_rendered_with_bootstrap_install_command_on_12_5_client.txt
+++ b/spec/assets/win_template_rendered_with_bootstrap_install_command_on_12_5_client.txt
@@ -208,7 +208,7 @@ echo.# Using default node name ^(fqdn^)
 echo.log_level        :info
 echo.log_location       STDOUT
 echo.rubygems_url "https://rubygems.org"
- 
+
 )
 
 > C:\chef\first-boot.json (

--- a/spec/assets/win_template_rendered_with_bootstrap_install_command_on_12_5_client.txt
+++ b/spec/assets/win_template_rendered_with_bootstrap_install_command_on_12_5_client.txt
@@ -208,7 +208,7 @@ echo.# Using default node name ^(fqdn^)
 echo.log_level        :info
 echo.log_location       STDOUT
 echo.rubygems_url "https://rubygems.org"
-
+ 
 )
 
 > C:\chef\first-boot.json (

--- a/spec/assets/win_template_rendered_without_bootstrap_install_command.txt
+++ b/spec/assets/win_template_rendered_without_bootstrap_install_command.txt
@@ -1,38 +1,38 @@
-@rem 
-@rem Author:: Seth Chisamore (<schisamo@opscode.com>) 
-@rem Copyright:: Copyright (c) 2011 Opscode, Inc. 
-@rem License:: Apache License, Version 2.0 
-@rem 
-@rem Licensed under the Apache License, Version 2.0 (the "License"); 
-@rem you may not use this file except in compliance with the License. 
-@rem You may obtain a copy of the License at 
-@rem 
-@rem     http://www.apache.org/licenses/LICENSE-2.0 
-@rem 
-@rem Unless required by applicable law or agreed to in writing, software 
-@rem distributed under the License is distributed on an "AS IS" BASIS, 
-@rem WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
-@rem See the License for the specific language governing permissions and 
-@rem limitations under the License. 
-@rem 
+@rem
+@rem Author:: Seth Chisamore (<schisamo@opscode.com>)
+@rem Copyright:: Copyright (c) 2011 Opscode, Inc.
+@rem License:: Apache License, Version 2.0
+@rem
+@rem Licensed under the Apache License, Version 2.0 (the "License");
+@rem you may not use this file except in compliance with the License.
+@rem You may obtain a copy of the License at
+@rem
+@rem     http://www.apache.org/licenses/LICENSE-2.0
+@rem
+@rem Unless required by applicable law or agreed to in writing, software
+@rem distributed under the License is distributed on an "AS IS" BASIS,
+@rem WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+@rem See the License for the specific language governing permissions and
+@rem limitations under the License.
+@rem
 
-@rem Use delayed environment expansion so that ERRORLEVEL can be evaluated with the 
-@rem !ERRORLEVEL! syntax which evaluates at execution of the line of script, not when 
-@rem the line is read. See help for the /E switch from cmd.exe /? . 
-@setlocal ENABLEDELAYEDEXPANSION 
+@rem Use delayed environment expansion so that ERRORLEVEL can be evaluated with the
+@rem !ERRORLEVEL! syntax which evaluates at execution of the line of script, not when
+@rem the line is read. See help for the /E switch from cmd.exe /? .
+@setlocal ENABLEDELAYEDEXPANSION
 
- 
 
-@set BOOTSTRAP_DIRECTORY=C:\chef 
-@echo Checking for existing directory "%BOOTSTRAP_DIRECTORY%"... 
-@if NOT EXIST %BOOTSTRAP_DIRECTORY% ( 
-    @echo Existing directory not found, creating. 
-    @mkdir %BOOTSTRAP_DIRECTORY% 
-) else ( 
-    @echo Existing directory found, skipping creation. 
-) 
 
-> C:\chef\wget.vbs ( 
+@set BOOTSTRAP_DIRECTORY=C:\chef
+@echo Checking for existing directory "%BOOTSTRAP_DIRECTORY%"...
+@if NOT EXIST %BOOTSTRAP_DIRECTORY% (
+    @echo Existing directory not found, creating.
+    @mkdir %BOOTSTRAP_DIRECTORY%
+) else (
+    @echo Existing directory found, skipping creation.
+)
+
+> C:\chef\wget.vbs (
  echo.url = WScript.Arguments.Named^("url"^)
 echo.path = WScript.Arguments.Named^("path"^)
 echo.proxy = null
@@ -95,10 +95,10 @@ echo.Set objADOStream = Nothing
 echo.End If
 echo.Set objXMLHTTP = Nothing
 echo.End If
- 
-) 
 
-> C:\chef\wget.ps1 ( 
+)
+
+> C:\chef\wget.ps1 (
  echo.param^(
 echo.   [String] $remoteUrl,
 echo.   [String] $localPath
@@ -113,144 +113,144 @@ echo.  $WebClient.Proxy = $WebProxy
 echo.}
 echo.
 echo.$webClient.DownloadFile^($remoteUrl, $localPath^);
- 
-) 
 
-@rem Determine the version and the architecture 
+)
 
-@FOR /F "usebackq tokens=1-8 delims=.[] " %%A IN (`ver`) DO ( 
-@set WinMajor=%%D 
-@set WinMinor=%%E 
-@set WinBuild=%%F 
-) 
+@rem Determine the version and the architecture
 
-@echo Detected Windows Version %WinMajor%.%WinMinor% Build %WinBuild% 
+@FOR /F "usebackq tokens=1-8 delims=.[] " %%A IN (`ver`) DO (
+@set WinMajor=%%D
+@set WinMinor=%%E
+@set WinBuild=%%F
+)
 
-@set LATEST_OS_VERSION_MAJOR=6 
-@set LATEST_OS_VERSION_MINOR=3 
+@echo Detected Windows Version %WinMajor%.%WinMinor% Build %WinBuild%
 
-@if /i %WinMajor% GTR %LATEST_OS_VERSION_MAJOR% goto VersionUnknown 
-@if /i %WinMajor% EQU %LATEST_OS_VERSION_MAJOR%  ( 
-  @if /i %WinMinor% GTR %LATEST_OS_VERSION_MINOR% goto VersionUnknown 
-) 
+@set LATEST_OS_VERSION_MAJOR=6
+@set LATEST_OS_VERSION_MINOR=3
 
-goto Version%WinMajor%.%WinMinor% 
+@if /i %WinMajor% GTR %LATEST_OS_VERSION_MAJOR% goto VersionUnknown
+@if /i %WinMajor% EQU %LATEST_OS_VERSION_MAJOR%  (
+  @if /i %WinMinor% GTR %LATEST_OS_VERSION_MINOR% goto VersionUnknown
+)
 
-:VersionUnknown 
-@rem If this is an unknown version of windows set the default 
-@set MACHINE_OS=2008r2 
-@echo Warning: Unknown version of Windows, assuming default of Windows %MACHINE_OS% 
-goto architecture_select 
+goto Version%WinMajor%.%WinMinor%
 
-:Version6.0 
-@set MACHINE_OS=2008 
-goto architecture_select 
+:VersionUnknown
+@rem If this is an unknown version of windows set the default
+@set MACHINE_OS=2008r2
+@echo Warning: Unknown version of Windows, assuming default of Windows %MACHINE_OS%
+goto architecture_select
 
-:Version5.2 
-@set MACHINE_OS=2003r2 
-goto architecture_select 
+:Version6.0
+@set MACHINE_OS=2008
+goto architecture_select
 
-:Version6.1 
-@set MACHINE_OS=2008r2 
-goto architecture_select 
+:Version5.2
+@set MACHINE_OS=2003r2
+goto architecture_select
 
-:Version6.2 
-@set MACHINE_OS=2012 
-goto architecture_select 
+:Version6.1
+@set MACHINE_OS=2008r2
+goto architecture_select
 
-@rem Currently Windows Server 2012 R2 is treated as equivalent to Windows Server 2012 
-:Version6.3 
-goto Version6.2 
+:Version6.2
+@set MACHINE_OS=2012
+goto architecture_select
 
-:architecture_select 
-goto Architecture%PROCESSOR_ARCHITEW6432% 
+@rem Currently Windows Server 2012 R2 is treated as equivalent to Windows Server 2012
+:Version6.3
+goto Version6.2
 
-:Architecture 
-goto Architecture%PROCESSOR_ARCHITECTURE% 
+:architecture_select
+goto Architecture%PROCESSOR_ARCHITEW6432%
 
-@rem If this is an unknown architecture set the default 
-@set MACHINE_ARCH=i686 
-goto install 
+:Architecture
+goto Architecture%PROCESSOR_ARCHITECTURE%
 
-:Architecturex86 
-@set MACHINE_ARCH=i686 
-goto install 
+@rem If this is an unknown architecture set the default
+@set MACHINE_ARCH=i686
+goto install
 
-:Architectureamd64 
-@set MACHINE_ARCH=x86_64 
-goto install 
+:Architecturex86
+@set MACHINE_ARCH=i686
+goto install
 
-:install 
-@rem If user has provided the custom installation command for chef-client then execute it 
-  @rem Install Chef using chef-client MSI installer 
+:Architectureamd64
+@set MACHINE_ARCH=x86_64
+goto install
 
-  @set "LOCAL_DESTINATION_MSI_PATH=%TEMP%\chef-client-latest.msi" 
-  @set "CHEF_CLIENT_MSI_LOG_PATH=%TEMP%\chef-client-msi%RANDOM%.log" 
+:install
+@rem If user has provided the custom installation command for chef-client then execute it
+  @rem Install Chef using chef-client MSI installer
 
-  @rem Clear any pre-existing downloads 
-  @echo Checking for existing downloaded package at "%LOCAL_DESTINATION_MSI_PATH%" 
-  @if EXIST "%LOCAL_DESTINATION_MSI_PATH%" ( 
-      @echo Found existing downloaded package, deleting. 
-      @del /f /q "%LOCAL_DESTINATION_MSI_PATH%" 
-      @if ERRORLEVEL 1 ( 
-          echo Warning: Failed to delete pre-existing package with status code !ERRORLEVEL! > "&2" 
-      ) 
-  ) else ( 
-      echo No existing downloaded packages to delete. 
-    ) 
+  @set "LOCAL_DESTINATION_MSI_PATH=%TEMP%\chef-client-latest.msi"
+  @set "CHEF_CLIENT_MSI_LOG_PATH=%TEMP%\chef-client-msi%RANDOM%.log"
 
-  @rem If there is somehow a name collision, remove pre-existing log 
-  @if EXIST "%CHEF_CLIENT_MSI_LOG_PATH%" del /f /q "%CHEF_CLIENT_MSI_LOG_PATH%" 
+  @rem Clear any pre-existing downloads
+  @echo Checking for existing downloaded package at "%LOCAL_DESTINATION_MSI_PATH%"
+  @if EXIST "%LOCAL_DESTINATION_MSI_PATH%" (
+      @echo Found existing downloaded package, deleting.
+      @del /f /q "%LOCAL_DESTINATION_MSI_PATH%"
+      @if ERRORLEVEL 1 (
+          echo Warning: Failed to delete pre-existing package with status code !ERRORLEVEL! > "&2"
+      )
+  ) else (
+      echo No existing downloaded packages to delete.
+    )
 
-  @echo Attempting to download client package using PowerShell if available... 
-  @set "REMOTE_SOURCE_MSI_URL=https://www.chef.io/chef/download?p=windows&pv=%MACHINE_OS%&m=%MACHINE_ARCH%&DownloadContext=PowerShell&v=12" 
-  @set powershell_download=powershell.exe -ExecutionPolicy Unrestricted -NoProfile -NonInteractive -File  C:\chef\wget.ps1 "%REMOTE_SOURCE_MSI_URL%" "%LOCAL_DESTINATION_MSI_PATH%" 
-  @echo !powershell_download! 
-  @call !powershell_download! 
+  @rem If there is somehow a name collision, remove pre-existing log
+  @if EXIST "%CHEF_CLIENT_MSI_LOG_PATH%" del /f /q "%CHEF_CLIENT_MSI_LOG_PATH%"
 
-  @set DOWNLOAD_ERROR_STATUS=!ERRORLEVEL! 
+  @echo Attempting to download client package using PowerShell if available...
+  @set "REMOTE_SOURCE_MSI_URL=https://www.chef.io/chef/download?p=windows&pv=%MACHINE_OS%&m=%MACHINE_ARCH%&DownloadContext=PowerShell&v=12"
+  @set powershell_download=powershell.exe -ExecutionPolicy Unrestricted -NoProfile -NonInteractive -File  C:\chef\wget.ps1 "%REMOTE_SOURCE_MSI_URL%" "%LOCAL_DESTINATION_MSI_PATH%"
+  @echo !powershell_download!
+  @call !powershell_download!
 
-  @if ERRORLEVEL 1 ( 
-      @echo Failed PowerShell download with status code !DOWNLOAD_ERROR_STATUS! > "&2" 
-      @if !DOWNLOAD_ERROR_STATUS!==0 set DOWNLOAD_ERROR_STATUS=2 
-  ) else ( 
-      @rem Sometimes the error level is not set even when the download failed, 
-      @rem so check for the file to be sure it is there -- if it is not, we will retry 
-      @if NOT EXIST "%LOCAL_DESTINATION_MSI_PATH%" ( 
-          echo Failed download: download completed, but downloaded file not found > "&2" 
-          set DOWNLOAD_ERROR_STATUS=2 
-      ) else ( 
-          echo Download via PowerShell succeeded. 
-        ) 
-    ) 
+  @set DOWNLOAD_ERROR_STATUS=!ERRORLEVEL!
 
-  @if NOT %DOWNLOAD_ERROR_STATUS%==0 ( 
-      @echo Warning: Failed to download "%REMOTE_SOURCE_MSI_URL%" to "%LOCAL_DESTINATION_MSI_PATH%" 
-      @echo Warning: Retrying download with cscript ... 
+  @if ERRORLEVEL 1 (
+      @echo Failed PowerShell download with status code !DOWNLOAD_ERROR_STATUS! > "&2"
+      @if !DOWNLOAD_ERROR_STATUS!==0 set DOWNLOAD_ERROR_STATUS=2
+  ) else (
+      @rem Sometimes the error level is not set even when the download failed,
+      @rem so check for the file to be sure it is there -- if it is not, we will retry
+      @if NOT EXIST "%LOCAL_DESTINATION_MSI_PATH%" (
+          echo Failed download: download completed, but downloaded file not found > "&2"
+          set DOWNLOAD_ERROR_STATUS=2
+      ) else (
+          echo Download via PowerShell succeeded.
+        )
+    )
 
-      @if EXIST "%LOCAL_DESTINATION_MSI_PATH%" del /f /q "%LOCAL_DESTINATION_MSI_PATH%" 
+  @if NOT %DOWNLOAD_ERROR_STATUS%==0 (
+      @echo Warning: Failed to download "%REMOTE_SOURCE_MSI_URL%" to "%LOCAL_DESTINATION_MSI_PATH%"
+      @echo Warning: Retrying download with cscript ...
 
-      @set "REMOTE_SOURCE_MSI_URL=https://www.chef.io/chef/download?p=windows&pv=%MACHINE_OS%&m=%MACHINE_ARCH%&v=12" 
-      cscript /nologo C:\chef\wget.vbs /url:"%REMOTE_SOURCE_MSI_URL%" /path:"%LOCAL_DESTINATION_MSI_PATH%" 
+      @if EXIST "%LOCAL_DESTINATION_MSI_PATH%" del /f /q "%LOCAL_DESTINATION_MSI_PATH%"
 
-      @if NOT ERRORLEVEL 1 ( 
-          @rem Sometimes the error level is not set even when the download failed, 
-          @rem so check for the file to be sure it is there. 
-          @if NOT EXIST "%LOCAL_DESTINATION_MSI_PATH%" ( 
-              echo Failed download: download completed, but downloaded file not found > "&2" 
-              echo Exiting without bootstrapping due to download failure. > "&2" 
-              exit /b 1 
-          ) else ( 
-              echo Download via cscript succeeded. 
-            ) 
-      ) else ( 
-          echo Failed to download "%REMOTE_SOURCE_MSI_URL%" with status code !ERRORLEVEL!. > "&2" 
-          echo Exiting without bootstrapping due to download failure. > "&2" 
-          exit /b 1 
-        ) 
-  ) 
+      @set "REMOTE_SOURCE_MSI_URL=https://www.chef.io/chef/download?p=windows&pv=%MACHINE_OS%&m=%MACHINE_ARCH%&v=12"
+      cscript /nologo C:\chef\wget.vbs /url:"%REMOTE_SOURCE_MSI_URL%" /path:"%LOCAL_DESTINATION_MSI_PATH%"
 
-  @echo Installing downloaded client package... 
+      @if NOT ERRORLEVEL 1 (
+          @rem Sometimes the error level is not set even when the download failed,
+          @rem so check for the file to be sure it is there.
+          @if NOT EXIST "%LOCAL_DESTINATION_MSI_PATH%" (
+              echo Failed download: download completed, but downloaded file not found > "&2"
+              echo Exiting without bootstrapping due to download failure. > "&2"
+              exit /b 1
+          ) else (
+              echo Download via cscript succeeded.
+            )
+      ) else (
+          echo Failed to download "%REMOTE_SOURCE_MSI_URL%" with status code !ERRORLEVEL!. > "&2"
+          echo Exiting without bootstrapping due to download failure. > "&2"
+          exit /b 1
+        )
+  )
+
+  @echo Installing downloaded client package...
 
   msiexec /qn /log "%CHEF_CLIENT_MSI_LOG_PATH%" /i "%LOCAL_DESTINATION_MSI_PATH%"
           @set MSIERRORCODE=!ERRORLEVEL!
@@ -285,32 +285,32 @@ goto install
           ) else (
               @echo Successfully installed Chef Client package.
           )
- 
-
-  @if ERRORLEVEL 1 ( 
-      echo Chef-client package failed to install with status code !ERRORLEVEL!. > "&2" 
-      echo See installation log for additional detail: %CHEF_CLIENT_MSI_LOG_PATH%. > "&2" 
-  ) else ( 
-      @echo Installation completed successfully 
-      del /f /q "%CHEF_CLIENT_MSI_LOG_PATH%" 
-    ) 
 
 
-@endlocal 
-
-@echo off 
-
-
-echo Writing validation key... 
-
-
-echo Validation key written. 
-@echo on 
+  @if ERRORLEVEL 1 (
+      echo Chef-client package failed to install with status code !ERRORLEVEL!. > "&2"
+      echo See installation log for additional detail: %CHEF_CLIENT_MSI_LOG_PATH%. > "&2"
+  ) else (
+      @echo Installation completed successfully
+      del /f /q "%CHEF_CLIENT_MSI_LOG_PATH%"
+    )
 
 
+@endlocal
+
+@echo off
 
 
-> C:\chef\client.rb ( 
+echo Writing validation key...
+
+
+echo Validation key written.
+@echo on
+
+
+
+
+> C:\chef\client.rb (
  echo.chef_server_url  "https://localhost:443"
 echo.validation_client_name "chef-validator"
 echo.file_cache_path   "c:/chef/cache"
@@ -320,14 +320,13 @@ echo.# Using default node name ^(fqdn^)
 echo.log_level        :info
 echo.log_location       STDOUT
 echo.rubygems_url "https://rubygems.org"
+ 
+)
 
-) 
+> C:\chef\first-boot.json (
+ echo.{"run_list":null}
+)
 
-> C:\chef\first-boot.json ( 
- echo.{"run_list":null} 
-) 
-
-@echo Starting chef to bootstrap the node... 
+@echo Starting chef to bootstrap the node...
 SET "PATH=%PATH%;C:\ruby\bin;C:\opscode\chef\bin;C:\opscode\chef\embedded\bin"
 chef-client -c c:/chef/client.rb -j c:/chef/first-boot.json
- 

--- a/spec/assets/win_template_rendered_without_bootstrap_install_command.txt
+++ b/spec/assets/win_template_rendered_without_bootstrap_install_command.txt
@@ -320,7 +320,6 @@ echo.# Using default node name ^(fqdn^)
 echo.log_level        :info
 echo.log_location       STDOUT
 echo.rubygems_url "https://rubygems.org"
- 
 )
 
 > C:\chef\first-boot.json (

--- a/spec/assets/win_template_rendered_without_bootstrap_install_command.txt
+++ b/spec/assets/win_template_rendered_without_bootstrap_install_command.txt
@@ -319,7 +319,8 @@ echo.cache_options     ^({:path =^> "c:/chef/cache/checksums", :skip_expires =^>
 echo.# Using default node name ^(fqdn^)
 echo.log_level        :info
 echo.log_location       STDOUT
- 
+echo.rubygems_url "https://rubygems.org"
+
 ) 
 
 > C:\chef\first-boot.json ( 

--- a/spec/assets/win_template_rendered_without_bootstrap_install_command.txt
+++ b/spec/assets/win_template_rendered_without_bootstrap_install_command.txt
@@ -320,7 +320,7 @@ echo.# Using default node name ^(fqdn^)
 echo.log_level        :info
 echo.log_location       STDOUT
 echo.rubygems_url "https://rubygems.org"
-
+ 
 )
 
 > C:\chef\first-boot.json (

--- a/spec/assets/win_template_rendered_without_bootstrap_install_command.txt
+++ b/spec/assets/win_template_rendered_without_bootstrap_install_command.txt
@@ -320,7 +320,7 @@ echo.# Using default node name ^(fqdn^)
 echo.log_level        :info
 echo.log_location       STDOUT
 echo.rubygems_url "https://rubygems.org"
- 
+
 )
 
 > C:\chef\first-boot.json (

--- a/spec/assets/win_template_rendered_without_bootstrap_install_command_on_12_5_client.txt
+++ b/spec/assets/win_template_rendered_without_bootstrap_install_command_on_12_5_client.txt
@@ -1,38 +1,38 @@
-@rem 
-@rem Author:: Seth Chisamore (<schisamo@opscode.com>) 
-@rem Copyright:: Copyright (c) 2011 Opscode, Inc. 
-@rem License:: Apache License, Version 2.0 
-@rem 
-@rem Licensed under the Apache License, Version 2.0 (the "License"); 
-@rem you may not use this file except in compliance with the License. 
-@rem You may obtain a copy of the License at 
-@rem 
-@rem     http://www.apache.org/licenses/LICENSE-2.0 
-@rem 
-@rem Unless required by applicable law or agreed to in writing, software 
-@rem distributed under the License is distributed on an "AS IS" BASIS, 
-@rem WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
-@rem See the License for the specific language governing permissions and 
-@rem limitations under the License. 
-@rem 
+@rem
+@rem Author:: Seth Chisamore (<schisamo@opscode.com>)
+@rem Copyright:: Copyright (c) 2011 Opscode, Inc.
+@rem License:: Apache License, Version 2.0
+@rem
+@rem Licensed under the Apache License, Version 2.0 (the "License");
+@rem you may not use this file except in compliance with the License.
+@rem You may obtain a copy of the License at
+@rem
+@rem     http://www.apache.org/licenses/LICENSE-2.0
+@rem
+@rem Unless required by applicable law or agreed to in writing, software
+@rem distributed under the License is distributed on an "AS IS" BASIS,
+@rem WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+@rem See the License for the specific language governing permissions and
+@rem limitations under the License.
+@rem
 
-@rem Use delayed environment expansion so that ERRORLEVEL can be evaluated with the 
-@rem !ERRORLEVEL! syntax which evaluates at execution of the line of script, not when 
-@rem the line is read. See help for the /E switch from cmd.exe /? . 
-@setlocal ENABLEDELAYEDEXPANSION 
+@rem Use delayed environment expansion so that ERRORLEVEL can be evaluated with the
+@rem !ERRORLEVEL! syntax which evaluates at execution of the line of script, not when
+@rem the line is read. See help for the /E switch from cmd.exe /? .
+@setlocal ENABLEDELAYEDEXPANSION
 
- 
 
-@set BOOTSTRAP_DIRECTORY=C:\chef 
-@echo Checking for existing directory "%BOOTSTRAP_DIRECTORY%"... 
-@if NOT EXIST %BOOTSTRAP_DIRECTORY% ( 
-    @echo Existing directory not found, creating. 
-    @mkdir %BOOTSTRAP_DIRECTORY% 
-) else ( 
-    @echo Existing directory found, skipping creation. 
-) 
 
-> C:\chef\wget.vbs ( 
+@set BOOTSTRAP_DIRECTORY=C:\chef
+@echo Checking for existing directory "%BOOTSTRAP_DIRECTORY%"...
+@if NOT EXIST %BOOTSTRAP_DIRECTORY% (
+    @echo Existing directory not found, creating.
+    @mkdir %BOOTSTRAP_DIRECTORY%
+) else (
+    @echo Existing directory found, skipping creation.
+)
+
+> C:\chef\wget.vbs (
  echo.url = WScript.Arguments.Named^("url"^)
 echo.path = WScript.Arguments.Named^("path"^)
 echo.proxy = null
@@ -95,10 +95,10 @@ echo.Set objADOStream = Nothing
 echo.End If
 echo.Set objXMLHTTP = Nothing
 echo.End If
- 
-) 
 
-> C:\chef\wget.ps1 ( 
+)
+
+> C:\chef\wget.ps1 (
  echo.param^(
 echo.   [String] $remoteUrl,
 echo.   [String] $localPath
@@ -113,144 +113,144 @@ echo.  $WebClient.Proxy = $WebProxy
 echo.}
 echo.
 echo.$webClient.DownloadFile^($remoteUrl, $localPath^);
- 
-) 
 
-@rem Determine the version and the architecture 
+)
 
-@FOR /F "usebackq tokens=1-8 delims=.[] " %%A IN (`ver`) DO ( 
-@set WinMajor=%%D 
-@set WinMinor=%%E 
-@set WinBuild=%%F 
-) 
+@rem Determine the version and the architecture
 
-@echo Detected Windows Version %WinMajor%.%WinMinor% Build %WinBuild% 
+@FOR /F "usebackq tokens=1-8 delims=.[] " %%A IN (`ver`) DO (
+@set WinMajor=%%D
+@set WinMinor=%%E
+@set WinBuild=%%F
+)
 
-@set LATEST_OS_VERSION_MAJOR=6 
-@set LATEST_OS_VERSION_MINOR=3 
+@echo Detected Windows Version %WinMajor%.%WinMinor% Build %WinBuild%
 
-@if /i %WinMajor% GTR %LATEST_OS_VERSION_MAJOR% goto VersionUnknown 
-@if /i %WinMajor% EQU %LATEST_OS_VERSION_MAJOR%  ( 
-  @if /i %WinMinor% GTR %LATEST_OS_VERSION_MINOR% goto VersionUnknown 
-) 
+@set LATEST_OS_VERSION_MAJOR=6
+@set LATEST_OS_VERSION_MINOR=3
 
-goto Version%WinMajor%.%WinMinor% 
+@if /i %WinMajor% GTR %LATEST_OS_VERSION_MAJOR% goto VersionUnknown
+@if /i %WinMajor% EQU %LATEST_OS_VERSION_MAJOR%  (
+  @if /i %WinMinor% GTR %LATEST_OS_VERSION_MINOR% goto VersionUnknown
+)
 
-:VersionUnknown 
-@rem If this is an unknown version of windows set the default 
-@set MACHINE_OS=2008r2 
-@echo Warning: Unknown version of Windows, assuming default of Windows %MACHINE_OS% 
-goto architecture_select 
+goto Version%WinMajor%.%WinMinor%
 
-:Version6.0 
-@set MACHINE_OS=2008 
-goto architecture_select 
+:VersionUnknown
+@rem If this is an unknown version of windows set the default
+@set MACHINE_OS=2008r2
+@echo Warning: Unknown version of Windows, assuming default of Windows %MACHINE_OS%
+goto architecture_select
 
-:Version5.2 
-@set MACHINE_OS=2003r2 
-goto architecture_select 
+:Version6.0
+@set MACHINE_OS=2008
+goto architecture_select
 
-:Version6.1 
-@set MACHINE_OS=2008r2 
-goto architecture_select 
+:Version5.2
+@set MACHINE_OS=2003r2
+goto architecture_select
 
-:Version6.2 
-@set MACHINE_OS=2012 
-goto architecture_select 
+:Version6.1
+@set MACHINE_OS=2008r2
+goto architecture_select
 
-@rem Currently Windows Server 2012 R2 is treated as equivalent to Windows Server 2012 
-:Version6.3 
-goto Version6.2 
+:Version6.2
+@set MACHINE_OS=2012
+goto architecture_select
 
-:architecture_select 
-goto Architecture%PROCESSOR_ARCHITEW6432% 
+@rem Currently Windows Server 2012 R2 is treated as equivalent to Windows Server 2012
+:Version6.3
+goto Version6.2
 
-:Architecture 
-goto Architecture%PROCESSOR_ARCHITECTURE% 
+:architecture_select
+goto Architecture%PROCESSOR_ARCHITEW6432%
 
-@rem If this is an unknown architecture set the default 
-@set MACHINE_ARCH=i686 
-goto install 
+:Architecture
+goto Architecture%PROCESSOR_ARCHITECTURE%
 
-:Architecturex86 
-@set MACHINE_ARCH=i686 
-goto install 
+@rem If this is an unknown architecture set the default
+@set MACHINE_ARCH=i686
+goto install
 
-:Architectureamd64 
-@set MACHINE_ARCH=x86_64 
-goto install 
+:Architecturex86
+@set MACHINE_ARCH=i686
+goto install
 
-:install 
-@rem If user has provided the custom installation command for chef-client then execute it 
-  @rem Install Chef using chef-client MSI installer 
+:Architectureamd64
+@set MACHINE_ARCH=x86_64
+goto install
 
-  @set "LOCAL_DESTINATION_MSI_PATH=%TEMP%\chef-client-latest.msi" 
-  @set "CHEF_CLIENT_MSI_LOG_PATH=%TEMP%\chef-client-msi%RANDOM%.log" 
+:install
+@rem If user has provided the custom installation command for chef-client then execute it
+  @rem Install Chef using chef-client MSI installer
 
-  @rem Clear any pre-existing downloads 
-  @echo Checking for existing downloaded package at "%LOCAL_DESTINATION_MSI_PATH%" 
-  @if EXIST "%LOCAL_DESTINATION_MSI_PATH%" ( 
-      @echo Found existing downloaded package, deleting. 
-      @del /f /q "%LOCAL_DESTINATION_MSI_PATH%" 
-      @if ERRORLEVEL 1 ( 
-          echo Warning: Failed to delete pre-existing package with status code !ERRORLEVEL! > "&2" 
-      ) 
-  ) else ( 
-      echo No existing downloaded packages to delete. 
-    ) 
+  @set "LOCAL_DESTINATION_MSI_PATH=%TEMP%\chef-client-latest.msi"
+  @set "CHEF_CLIENT_MSI_LOG_PATH=%TEMP%\chef-client-msi%RANDOM%.log"
 
-  @rem If there is somehow a name collision, remove pre-existing log 
-  @if EXIST "%CHEF_CLIENT_MSI_LOG_PATH%" del /f /q "%CHEF_CLIENT_MSI_LOG_PATH%" 
+  @rem Clear any pre-existing downloads
+  @echo Checking for existing downloaded package at "%LOCAL_DESTINATION_MSI_PATH%"
+  @if EXIST "%LOCAL_DESTINATION_MSI_PATH%" (
+      @echo Found existing downloaded package, deleting.
+      @del /f /q "%LOCAL_DESTINATION_MSI_PATH%"
+      @if ERRORLEVEL 1 (
+          echo Warning: Failed to delete pre-existing package with status code !ERRORLEVEL! > "&2"
+      )
+  ) else (
+      echo No existing downloaded packages to delete.
+    )
 
-  @echo Attempting to download client package using PowerShell if available... 
-  @set "REMOTE_SOURCE_MSI_URL=https://www.chef.io/chef/download?p=windows&pv=%MACHINE_OS%&m=%MACHINE_ARCH%&DownloadContext=PowerShell&v=12" 
-  @set powershell_download=powershell.exe -ExecutionPolicy Unrestricted -NoProfile -NonInteractive -File  C:\chef\wget.ps1 "%REMOTE_SOURCE_MSI_URL%" "%LOCAL_DESTINATION_MSI_PATH%" 
-  @echo !powershell_download! 
-  @call !powershell_download! 
+  @rem If there is somehow a name collision, remove pre-existing log
+  @if EXIST "%CHEF_CLIENT_MSI_LOG_PATH%" del /f /q "%CHEF_CLIENT_MSI_LOG_PATH%"
 
-  @set DOWNLOAD_ERROR_STATUS=!ERRORLEVEL! 
+  @echo Attempting to download client package using PowerShell if available...
+  @set "REMOTE_SOURCE_MSI_URL=https://www.chef.io/chef/download?p=windows&pv=%MACHINE_OS%&m=%MACHINE_ARCH%&DownloadContext=PowerShell&v=12"
+  @set powershell_download=powershell.exe -ExecutionPolicy Unrestricted -NoProfile -NonInteractive -File  C:\chef\wget.ps1 "%REMOTE_SOURCE_MSI_URL%" "%LOCAL_DESTINATION_MSI_PATH%"
+  @echo !powershell_download!
+  @call !powershell_download!
 
-  @if ERRORLEVEL 1 ( 
-      @echo Failed PowerShell download with status code !DOWNLOAD_ERROR_STATUS! > "&2" 
-      @if !DOWNLOAD_ERROR_STATUS!==0 set DOWNLOAD_ERROR_STATUS=2 
-  ) else ( 
-      @rem Sometimes the error level is not set even when the download failed, 
-      @rem so check for the file to be sure it is there -- if it is not, we will retry 
-      @if NOT EXIST "%LOCAL_DESTINATION_MSI_PATH%" ( 
-          echo Failed download: download completed, but downloaded file not found > "&2" 
-          set DOWNLOAD_ERROR_STATUS=2 
-      ) else ( 
-          echo Download via PowerShell succeeded. 
-        ) 
-    ) 
+  @set DOWNLOAD_ERROR_STATUS=!ERRORLEVEL!
 
-  @if NOT %DOWNLOAD_ERROR_STATUS%==0 ( 
-      @echo Warning: Failed to download "%REMOTE_SOURCE_MSI_URL%" to "%LOCAL_DESTINATION_MSI_PATH%" 
-      @echo Warning: Retrying download with cscript ... 
+  @if ERRORLEVEL 1 (
+      @echo Failed PowerShell download with status code !DOWNLOAD_ERROR_STATUS! > "&2"
+      @if !DOWNLOAD_ERROR_STATUS!==0 set DOWNLOAD_ERROR_STATUS=2
+  ) else (
+      @rem Sometimes the error level is not set even when the download failed,
+      @rem so check for the file to be sure it is there -- if it is not, we will retry
+      @if NOT EXIST "%LOCAL_DESTINATION_MSI_PATH%" (
+          echo Failed download: download completed, but downloaded file not found > "&2"
+          set DOWNLOAD_ERROR_STATUS=2
+      ) else (
+          echo Download via PowerShell succeeded.
+        )
+    )
 
-      @if EXIST "%LOCAL_DESTINATION_MSI_PATH%" del /f /q "%LOCAL_DESTINATION_MSI_PATH%" 
+  @if NOT %DOWNLOAD_ERROR_STATUS%==0 (
+      @echo Warning: Failed to download "%REMOTE_SOURCE_MSI_URL%" to "%LOCAL_DESTINATION_MSI_PATH%"
+      @echo Warning: Retrying download with cscript ...
 
-      @set "REMOTE_SOURCE_MSI_URL=https://www.chef.io/chef/download?p=windows&pv=%MACHINE_OS%&m=%MACHINE_ARCH%&v=12" 
-      cscript /nologo C:\chef\wget.vbs /url:"%REMOTE_SOURCE_MSI_URL%" /path:"%LOCAL_DESTINATION_MSI_PATH%" 
+      @if EXIST "%LOCAL_DESTINATION_MSI_PATH%" del /f /q "%LOCAL_DESTINATION_MSI_PATH%"
 
-      @if NOT ERRORLEVEL 1 ( 
-          @rem Sometimes the error level is not set even when the download failed, 
-          @rem so check for the file to be sure it is there. 
-          @if NOT EXIST "%LOCAL_DESTINATION_MSI_PATH%" ( 
-              echo Failed download: download completed, but downloaded file not found > "&2" 
-              echo Exiting without bootstrapping due to download failure. > "&2" 
-              exit /b 1 
-          ) else ( 
-              echo Download via cscript succeeded. 
-            ) 
-      ) else ( 
-          echo Failed to download "%REMOTE_SOURCE_MSI_URL%" with status code !ERRORLEVEL!. > "&2" 
-          echo Exiting without bootstrapping due to download failure. > "&2" 
-          exit /b 1 
-        ) 
-  ) 
+      @set "REMOTE_SOURCE_MSI_URL=https://www.chef.io/chef/download?p=windows&pv=%MACHINE_OS%&m=%MACHINE_ARCH%&v=12"
+      cscript /nologo C:\chef\wget.vbs /url:"%REMOTE_SOURCE_MSI_URL%" /path:"%LOCAL_DESTINATION_MSI_PATH%"
 
-  @echo Installing downloaded client package... 
+      @if NOT ERRORLEVEL 1 (
+          @rem Sometimes the error level is not set even when the download failed,
+          @rem so check for the file to be sure it is there.
+          @if NOT EXIST "%LOCAL_DESTINATION_MSI_PATH%" (
+              echo Failed download: download completed, but downloaded file not found > "&2"
+              echo Exiting without bootstrapping due to download failure. > "&2"
+              exit /b 1
+          ) else (
+              echo Download via cscript succeeded.
+            )
+      ) else (
+          echo Failed to download "%REMOTE_SOURCE_MSI_URL%" with status code !ERRORLEVEL!. > "&2"
+          echo Exiting without bootstrapping due to download failure. > "&2"
+          exit /b 1
+        )
+  )
+
+  @echo Installing downloaded client package...
 
   msiexec /qn /log "%CHEF_CLIENT_MSI_LOG_PATH%" /i "%LOCAL_DESTINATION_MSI_PATH%"
           @set MSIERRORCODE=!ERRORLEVEL!
@@ -285,32 +285,32 @@ goto install
           ) else (
               @echo Successfully installed Chef Client package.
           )
- 
-
-  @if ERRORLEVEL 1 ( 
-      echo Chef-client package failed to install with status code !ERRORLEVEL!. > "&2" 
-      echo See installation log for additional detail: %CHEF_CLIENT_MSI_LOG_PATH%. > "&2" 
-  ) else ( 
-      @echo Installation completed successfully 
-      del /f /q "%CHEF_CLIENT_MSI_LOG_PATH%" 
-    ) 
 
 
-@endlocal 
-
-@echo off 
-
-
-echo Writing validation key... 
-
-
-echo Validation key written. 
-@echo on 
+  @if ERRORLEVEL 1 (
+      echo Chef-client package failed to install with status code !ERRORLEVEL!. > "&2"
+      echo See installation log for additional detail: %CHEF_CLIENT_MSI_LOG_PATH%. > "&2"
+  ) else (
+      @echo Installation completed successfully
+      del /f /q "%CHEF_CLIENT_MSI_LOG_PATH%"
+    )
 
 
+@endlocal
+
+@echo off
 
 
-> C:\chef\client.rb ( 
+echo Writing validation key...
+
+
+echo Validation key written.
+@echo on
+
+
+
+
+> C:\chef\client.rb (
  echo.chef_server_url  "https://localhost:443"
 echo.validation_client_name "chef-validator"
 echo.file_cache_path   "c:/chef/cache"
@@ -320,14 +320,13 @@ echo.# Using default node name ^(fqdn^)
 echo.log_level        :info
 echo.log_location       STDOUT
 echo.rubygems_url "https://rubygems.org"
+ 
+)
 
-) 
+> C:\chef\first-boot.json (
+ echo.{"run_list":null}
+)
 
-> C:\chef\first-boot.json ( 
- echo.{"run_list":null} 
-) 
-
-@echo Starting chef to bootstrap the node... 
+@echo Starting chef to bootstrap the node...
 SET "PATH=%PATH%;C:\ruby\bin;C:\opscode\chef\bin;C:\opscode\chef\embedded\bin"
 chef-client -c c:/chef/client.rb -j c:/chef/first-boot.json
- 

--- a/spec/assets/win_template_rendered_without_bootstrap_install_command_on_12_5_client.txt
+++ b/spec/assets/win_template_rendered_without_bootstrap_install_command_on_12_5_client.txt
@@ -320,7 +320,6 @@ echo.# Using default node name ^(fqdn^)
 echo.log_level        :info
 echo.log_location       STDOUT
 echo.rubygems_url "https://rubygems.org"
- 
 )
 
 > C:\chef\first-boot.json (

--- a/spec/assets/win_template_rendered_without_bootstrap_install_command_on_12_5_client.txt
+++ b/spec/assets/win_template_rendered_without_bootstrap_install_command_on_12_5_client.txt
@@ -319,7 +319,8 @@ echo.cache_options     ^({:path =^> "c:/chef/cache/checksums", :skip_expires =^>
 echo.# Using default node name ^(fqdn^)
 echo.log_level        :info
 echo.log_location       STDOUT
- 
+echo.rubygems_url "https://rubygems.org"
+
 ) 
 
 > C:\chef\first-boot.json ( 

--- a/spec/assets/win_template_rendered_without_bootstrap_install_command_on_12_5_client.txt
+++ b/spec/assets/win_template_rendered_without_bootstrap_install_command_on_12_5_client.txt
@@ -320,7 +320,7 @@ echo.# Using default node name ^(fqdn^)
 echo.log_level        :info
 echo.log_location       STDOUT
 echo.rubygems_url "https://rubygems.org"
-
+ 
 )
 
 > C:\chef\first-boot.json (

--- a/spec/assets/win_template_rendered_without_bootstrap_install_command_on_12_5_client.txt
+++ b/spec/assets/win_template_rendered_without_bootstrap_install_command_on_12_5_client.txt
@@ -320,7 +320,7 @@ echo.# Using default node name ^(fqdn^)
 echo.log_level        :info
 echo.log_location       STDOUT
 echo.rubygems_url "https://rubygems.org"
- 
+
 )
 
 > C:\chef\first-boot.json (

--- a/spec/assets/win_template_unrendered.txt
+++ b/spec/assets/win_template_unrendered.txt
@@ -1,246 +1,246 @@
-@rem 
-@rem Author:: Seth Chisamore (<schisamo@opscode.com>) 
-@rem Copyright:: Copyright (c) 2011 Opscode, Inc. 
-@rem License:: Apache License, Version 2.0 
-@rem 
-@rem Licensed under the Apache License, Version 2.0 (the "License"); 
-@rem you may not use this file except in compliance with the License. 
-@rem You may obtain a copy of the License at 
-@rem 
-@rem     http://www.apache.org/licenses/LICENSE-2.0 
-@rem 
-@rem Unless required by applicable law or agreed to in writing, software 
-@rem distributed under the License is distributed on an "AS IS" BASIS, 
-@rem WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
-@rem See the License for the specific language governing permissions and 
-@rem limitations under the License. 
-@rem 
+@rem
+@rem Author:: Seth Chisamore (<schisamo@opscode.com>)
+@rem Copyright:: Copyright (c) 2011 Opscode, Inc.
+@rem License:: Apache License, Version 2.0
+@rem
+@rem Licensed under the Apache License, Version 2.0 (the "License");
+@rem you may not use this file except in compliance with the License.
+@rem You may obtain a copy of the License at
+@rem
+@rem     http://www.apache.org/licenses/LICENSE-2.0
+@rem
+@rem Unless required by applicable law or agreed to in writing, software
+@rem distributed under the License is distributed on an "AS IS" BASIS,
+@rem WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+@rem See the License for the specific language governing permissions and
+@rem limitations under the License.
+@rem
 
-@rem Use delayed environment expansion so that ERRORLEVEL can be evaluated with the 
-@rem !ERRORLEVEL! syntax which evaluates at execution of the line of script, not when 
-@rem the line is read. See help for the /E switch from cmd.exe /? . 
-@setlocal ENABLEDELAYEDEXPANSION 
+@rem Use delayed environment expansion so that ERRORLEVEL can be evaluated with the
+@rem !ERRORLEVEL! syntax which evaluates at execution of the line of script, not when
+@rem the line is read. See help for the /E switch from cmd.exe /? .
+@setlocal ENABLEDELAYEDEXPANSION
 
-<%= "SETX HTTP_PROXY \"#{knife_config[:bootstrap_proxy]}\"" if knife_config[:bootstrap_proxy] %> 
+<%= "SETX HTTP_PROXY \"#{knife_config[:bootstrap_proxy]}\"" if knife_config[:bootstrap_proxy] %>
 
-@set BOOTSTRAP_DIRECTORY=<%= bootstrap_directory %> 
-@echo Checking for existing directory "%BOOTSTRAP_DIRECTORY%"... 
-@if NOT EXIST %BOOTSTRAP_DIRECTORY% ( 
-    @echo Existing directory not found, creating. 
-    @mkdir %BOOTSTRAP_DIRECTORY% 
-) else ( 
-    @echo Existing directory found, skipping creation. 
-) 
+@set BOOTSTRAP_DIRECTORY=<%= bootstrap_directory %>
+@echo Checking for existing directory "%BOOTSTRAP_DIRECTORY%"...
+@if NOT EXIST %BOOTSTRAP_DIRECTORY% (
+    @echo Existing directory not found, creating.
+    @mkdir %BOOTSTRAP_DIRECTORY%
+) else (
+    @echo Existing directory found, skipping creation.
+)
 
-> <%= bootstrap_directory %>\wget.vbs ( 
- <%= win_wget %> 
-) 
+> <%= bootstrap_directory %>\wget.vbs (
+ <%= win_wget %>
+)
 
-> <%= bootstrap_directory %>\wget.ps1 ( 
- <%= win_wget_ps %> 
-) 
+> <%= bootstrap_directory %>\wget.ps1 (
+ <%= win_wget_ps %>
+)
 
-@rem Determine the version and the architecture 
+@rem Determine the version and the architecture
 
-@FOR /F "usebackq tokens=1-8 delims=.[] " %%A IN (`ver`) DO ( 
-@set WinMajor=%%D 
-@set WinMinor=%%E 
-@set WinBuild=%%F 
-) 
+@FOR /F "usebackq tokens=1-8 delims=.[] " %%A IN (`ver`) DO (
+@set WinMajor=%%D
+@set WinMinor=%%E
+@set WinBuild=%%F
+)
 
-@echo Detected Windows Version %WinMajor%.%WinMinor% Build %WinBuild% 
+@echo Detected Windows Version %WinMajor%.%WinMinor% Build %WinBuild%
 
-@set LATEST_OS_VERSION_MAJOR=6 
-@set LATEST_OS_VERSION_MINOR=3 
+@set LATEST_OS_VERSION_MAJOR=6
+@set LATEST_OS_VERSION_MINOR=3
 
-@if /i %WinMajor% GTR %LATEST_OS_VERSION_MAJOR% goto VersionUnknown 
-@if /i %WinMajor% EQU %LATEST_OS_VERSION_MAJOR%  ( 
-  @if /i %WinMinor% GTR %LATEST_OS_VERSION_MINOR% goto VersionUnknown 
-) 
+@if /i %WinMajor% GTR %LATEST_OS_VERSION_MAJOR% goto VersionUnknown
+@if /i %WinMajor% EQU %LATEST_OS_VERSION_MAJOR%  (
+  @if /i %WinMinor% GTR %LATEST_OS_VERSION_MINOR% goto VersionUnknown
+)
 
-goto Version%WinMajor%.%WinMinor% 
+goto Version%WinMajor%.%WinMinor%
 
-:VersionUnknown 
-@rem If this is an unknown version of windows set the default 
-@set MACHINE_OS=2008r2 
-@echo Warning: Unknown version of Windows, assuming default of Windows %MACHINE_OS% 
-goto architecture_select 
+:VersionUnknown
+@rem If this is an unknown version of windows set the default
+@set MACHINE_OS=2008r2
+@echo Warning: Unknown version of Windows, assuming default of Windows %MACHINE_OS%
+goto architecture_select
 
-:Version6.0 
-@set MACHINE_OS=2008 
-goto architecture_select 
+:Version6.0
+@set MACHINE_OS=2008
+goto architecture_select
 
-:Version5.2 
-@set MACHINE_OS=2003r2 
-goto architecture_select 
+:Version5.2
+@set MACHINE_OS=2003r2
+goto architecture_select
 
-:Version6.1 
-@set MACHINE_OS=2008r2 
-goto architecture_select 
+:Version6.1
+@set MACHINE_OS=2008r2
+goto architecture_select
 
-:Version6.2 
-@set MACHINE_OS=2012 
-goto architecture_select 
+:Version6.2
+@set MACHINE_OS=2012
+goto architecture_select
 
-@rem Currently Windows Server 2012 R2 is treated as equivalent to Windows Server 2012 
-:Version6.3 
-goto Version6.2 
+@rem Currently Windows Server 2012 R2 is treated as equivalent to Windows Server 2012
+:Version6.3
+goto Version6.2
 
-:architecture_select 
-goto Architecture%PROCESSOR_ARCHITEW6432% 
+:architecture_select
+goto Architecture%PROCESSOR_ARCHITEW6432%
 
-:Architecture 
-goto Architecture%PROCESSOR_ARCHITECTURE% 
+:Architecture
+goto Architecture%PROCESSOR_ARCHITECTURE%
 
-@rem If this is an unknown architecture set the default 
-@set MACHINE_ARCH=i686 
-goto install 
+@rem If this is an unknown architecture set the default
+@set MACHINE_ARCH=i686
+goto install
 
-:Architecturex86 
-@set MACHINE_ARCH=i686 
-goto install 
+:Architecturex86
+@set MACHINE_ARCH=i686
+goto install
 
-:Architectureamd64 
-@set MACHINE_ARCH=x86_64 
-goto install 
+:Architectureamd64
+@set MACHINE_ARCH=x86_64
+goto install
 
-:install 
-@rem If user has provided the custom installation command for chef-client then execute it 
-<% if @chef_config[:knife][:bootstrap_install_command] %> 
-  <%= @chef_config[:knife][:bootstrap_install_command] %> 
-<% else %> 
-  @rem Install Chef using chef-client MSI installer 
+:install
+@rem If user has provided the custom installation command for chef-client then execute it
+<% if @chef_config[:knife][:bootstrap_install_command] %>
+  <%= @chef_config[:knife][:bootstrap_install_command] %>
+<% else %>
+  @rem Install Chef using chef-client MSI installer
 
-  @set "LOCAL_DESTINATION_MSI_PATH=<%= local_download_path %>" 
-  @set "CHEF_CLIENT_MSI_LOG_PATH=%TEMP%\chef-client-msi%RANDOM%.log" 
+  @set "LOCAL_DESTINATION_MSI_PATH=<%= local_download_path %>"
+  @set "CHEF_CLIENT_MSI_LOG_PATH=%TEMP%\chef-client-msi%RANDOM%.log"
 
-  @rem Clear any pre-existing downloads 
-  @echo Checking for existing downloaded package at "%LOCAL_DESTINATION_MSI_PATH%" 
-  @if EXIST "%LOCAL_DESTINATION_MSI_PATH%" ( 
-      @echo Found existing downloaded package, deleting. 
-      @del /f /q "%LOCAL_DESTINATION_MSI_PATH%" 
-      @if ERRORLEVEL 1 ( 
-          echo Warning: Failed to delete pre-existing package with status code !ERRORLEVEL! > "&2" 
-      ) 
-  ) else ( 
-      echo No existing downloaded packages to delete. 
-    ) 
+  @rem Clear any pre-existing downloads
+  @echo Checking for existing downloaded package at "%LOCAL_DESTINATION_MSI_PATH%"
+  @if EXIST "%LOCAL_DESTINATION_MSI_PATH%" (
+      @echo Found existing downloaded package, deleting.
+      @del /f /q "%LOCAL_DESTINATION_MSI_PATH%"
+      @if ERRORLEVEL 1 (
+          echo Warning: Failed to delete pre-existing package with status code !ERRORLEVEL! > "&2"
+      )
+  ) else (
+      echo No existing downloaded packages to delete.
+    )
 
-  @rem If there is somehow a name collision, remove pre-existing log 
-  @if EXIST "%CHEF_CLIENT_MSI_LOG_PATH%" del /f /q "%CHEF_CLIENT_MSI_LOG_PATH%" 
+  @rem If there is somehow a name collision, remove pre-existing log
+  @if EXIST "%CHEF_CLIENT_MSI_LOG_PATH%" del /f /q "%CHEF_CLIENT_MSI_LOG_PATH%"
 
-  @echo Attempting to download client package using PowerShell if available... 
-  @set "REMOTE_SOURCE_MSI_URL=<%= msi_url('%MACHINE_OS%', '%MACHINE_ARCH%', 'PowerShell') %>" 
-  @set powershell_download=powershell.exe -ExecutionPolicy Unrestricted -NoProfile -NonInteractive -File  <%= bootstrap_directory %>\wget.ps1 "%REMOTE_SOURCE_MSI_URL%" "%LOCAL_DESTINATION_MSI_PATH%" 
-  @echo !powershell_download! 
-  @call !powershell_download! 
+  @echo Attempting to download client package using PowerShell if available...
+  @set "REMOTE_SOURCE_MSI_URL=<%= msi_url('%MACHINE_OS%', '%MACHINE_ARCH%', 'PowerShell') %>"
+  @set powershell_download=powershell.exe -ExecutionPolicy Unrestricted -NoProfile -NonInteractive -File  <%= bootstrap_directory %>\wget.ps1 "%REMOTE_SOURCE_MSI_URL%" "%LOCAL_DESTINATION_MSI_PATH%"
+  @echo !powershell_download!
+  @call !powershell_download!
 
-  @set DOWNLOAD_ERROR_STATUS=!ERRORLEVEL! 
+  @set DOWNLOAD_ERROR_STATUS=!ERRORLEVEL!
 
-  @if ERRORLEVEL 1 ( 
-      @echo Failed PowerShell download with status code !DOWNLOAD_ERROR_STATUS! > "&2" 
-      @if !DOWNLOAD_ERROR_STATUS!==0 set DOWNLOAD_ERROR_STATUS=2 
-  ) else ( 
-      @rem Sometimes the error level is not set even when the download failed, 
-      @rem so check for the file to be sure it is there -- if it is not, we will retry 
-      @if NOT EXIST "%LOCAL_DESTINATION_MSI_PATH%" ( 
-          echo Failed download: download completed, but downloaded file not found > "&2" 
-          set DOWNLOAD_ERROR_STATUS=2 
-      ) else ( 
-          echo Download via PowerShell succeeded. 
-        ) 
-    ) 
+  @if ERRORLEVEL 1 (
+      @echo Failed PowerShell download with status code !DOWNLOAD_ERROR_STATUS! > "&2"
+      @if !DOWNLOAD_ERROR_STATUS!==0 set DOWNLOAD_ERROR_STATUS=2
+  ) else (
+      @rem Sometimes the error level is not set even when the download failed,
+      @rem so check for the file to be sure it is there -- if it is not, we will retry
+      @if NOT EXIST "%LOCAL_DESTINATION_MSI_PATH%" (
+          echo Failed download: download completed, but downloaded file not found > "&2"
+          set DOWNLOAD_ERROR_STATUS=2
+      ) else (
+          echo Download via PowerShell succeeded.
+        )
+    )
 
-  @if NOT %DOWNLOAD_ERROR_STATUS%==0 ( 
-      @echo Warning: Failed to download "%REMOTE_SOURCE_MSI_URL%" to "%LOCAL_DESTINATION_MSI_PATH%" 
-      @echo Warning: Retrying download with cscript ... 
+  @if NOT %DOWNLOAD_ERROR_STATUS%==0 (
+      @echo Warning: Failed to download "%REMOTE_SOURCE_MSI_URL%" to "%LOCAL_DESTINATION_MSI_PATH%"
+      @echo Warning: Retrying download with cscript ...
 
-      @if EXIST "%LOCAL_DESTINATION_MSI_PATH%" del /f /q "%LOCAL_DESTINATION_MSI_PATH%" 
+      @if EXIST "%LOCAL_DESTINATION_MSI_PATH%" del /f /q "%LOCAL_DESTINATION_MSI_PATH%"
 
-      @set "REMOTE_SOURCE_MSI_URL=<%= msi_url('%MACHINE_OS%', '%MACHINE_ARCH%') %>" 
-      cscript /nologo <%= bootstrap_directory %>\wget.vbs /url:"%REMOTE_SOURCE_MSI_URL%" /path:"%LOCAL_DESTINATION_MSI_PATH%" 
+      @set "REMOTE_SOURCE_MSI_URL=<%= msi_url('%MACHINE_OS%', '%MACHINE_ARCH%') %>"
+      cscript /nologo <%= bootstrap_directory %>\wget.vbs /url:"%REMOTE_SOURCE_MSI_URL%" /path:"%LOCAL_DESTINATION_MSI_PATH%"
 
-      @if NOT ERRORLEVEL 1 ( 
-          @rem Sometimes the error level is not set even when the download failed, 
-          @rem so check for the file to be sure it is there. 
-          @if NOT EXIST "%LOCAL_DESTINATION_MSI_PATH%" ( 
-              echo Failed download: download completed, but downloaded file not found > "&2" 
-              echo Exiting without bootstrapping due to download failure. > "&2" 
-              exit /b 1 
-          ) else ( 
-              echo Download via cscript succeeded. 
-            ) 
-      ) else ( 
-          echo Failed to download "%REMOTE_SOURCE_MSI_URL%" with status code !ERRORLEVEL!. > "&2" 
-          echo Exiting without bootstrapping due to download failure. > "&2" 
-          exit /b 1 
-        ) 
-  ) 
+      @if NOT ERRORLEVEL 1 (
+          @rem Sometimes the error level is not set even when the download failed,
+          @rem so check for the file to be sure it is there.
+          @if NOT EXIST "%LOCAL_DESTINATION_MSI_PATH%" (
+              echo Failed download: download completed, but downloaded file not found > "&2"
+              echo Exiting without bootstrapping due to download failure. > "&2"
+              exit /b 1
+          ) else (
+              echo Download via cscript succeeded.
+            )
+      ) else (
+          echo Failed to download "%REMOTE_SOURCE_MSI_URL%" with status code !ERRORLEVEL!. > "&2"
+          echo Exiting without bootstrapping due to download failure. > "&2"
+          exit /b 1
+        )
+  )
 
-  @echo Installing downloaded client package... 
+  @echo Installing downloaded client package...
 
-  <%= install_chef %> 
+  <%= install_chef %>
 
-  @if ERRORLEVEL 1 ( 
-      echo Chef-client package failed to install with status code !ERRORLEVEL!. > "&2" 
-      echo See installation log for additional detail: %CHEF_CLIENT_MSI_LOG_PATH%. > "&2" 
-  ) else ( 
-      @echo Installation completed successfully 
-      del /f /q "%CHEF_CLIENT_MSI_LOG_PATH%" 
-    ) 
+  @if ERRORLEVEL 1 (
+      echo Chef-client package failed to install with status code !ERRORLEVEL!. > "&2"
+      echo See installation log for additional detail: %CHEF_CLIENT_MSI_LOG_PATH%. > "&2"
+  ) else (
+      @echo Installation completed successfully
+      del /f /q "%CHEF_CLIENT_MSI_LOG_PATH%"
+    )
 
-<% end %> 
+<% end %>
 
-@endlocal 
+@endlocal
 
-@echo off 
+@echo off
 
-<% if client_pem -%> 
-> <%= bootstrap_directory %>\client.pem ( 
- <%= escape_and_echo(::File.read(::File.expand_path(client_pem))) %> 
-) 
-<% end -%> 
+<% if client_pem -%>
+> <%= bootstrap_directory %>\client.pem (
+ <%= escape_and_echo(::File.read(::File.expand_path(client_pem))) %>
+)
+<% end -%>
 
-echo Writing validation key... 
+echo Writing validation key...
 
-<% if validation_key -%> 
-> <%= bootstrap_directory %>\validation.pem ( 
- <%= escape_and_echo(validation_key) %> 
-) 
-<% end -%> 
+<% if validation_key -%>
+> <%= bootstrap_directory %>\validation.pem (
+ <%= escape_and_echo(validation_key) %>
+)
+<% end -%>
 
-echo Validation key written. 
-@echo on 
+echo Validation key written.
+@echo on
 
-<% if @config[:secret] -%> 
-> <%= bootstrap_directory %>\encrypted_data_bag_secret ( 
- <%= secret %> 
-) 
-<% end -%> 
+<% if @config[:secret] -%>
+> <%= bootstrap_directory %>\encrypted_data_bag_secret (
+ <%= secret %>
+)
+<% end -%>
 
-<% unless trusted_certs_script.empty? -%> 
-mkdir <%= bootstrap_directory %>\trusted_certs 
-<%= trusted_certs_script %> 
-<% end -%> 
+<% unless trusted_certs_script.empty? -%>
+mkdir <%= bootstrap_directory %>\trusted_certs
+<%= trusted_certs_script %>
+<% end -%>
 
-<%# Generate Ohai Hints -%> 
-<% unless @chef_config[:knife][:hints].nil? || @chef_config[:knife][:hints].empty? -%> 
-mkdir <%= bootstrap_directory %>\ohai\hints 
+<%# Generate Ohai Hints -%>
+<% unless @chef_config[:knife][:hints].nil? || @chef_config[:knife][:hints].empty? -%>
+mkdir <%= bootstrap_directory %>\ohai\hints
 
-<% @chef_config[:knife][:hints].each do |name, hash| -%> 
-> <%= bootstrap_directory %>\ohai\hints\<%= name %>.json ( 
-  <%= escape_and_echo(hash.to_json) %> 
-) 
-<% end -%> 
-<% end -%> 
+<% @chef_config[:knife][:hints].each do |name, hash| -%>
+> <%= bootstrap_directory %>\ohai\hints\<%= name %>.json (
+  <%= escape_and_echo(hash.to_json) %>
+)
+<% end -%>
+<% end -%>
 
-> <%= bootstrap_directory %>\client.rb ( 
- <%= config_content %> 
-) 
+> <%= bootstrap_directory %>\client.rb (
+ <%= config_content %>
+)
 
-> <%= bootstrap_directory %>\first-boot.json ( 
- <%= first_boot %> 
-) 
+> <%= bootstrap_directory %>\first-boot.json (
+ <%= first_boot %>
+)
 
-@echo Starting chef to bootstrap the node... 
-<%= start_chef %> 
+@echo Starting chef to bootstrap the node...
+<%= start_chef %>


### PR DESCRIPTION
So normally Chef::Config[:rubygems_url] catch https://rubygems.org, but in order to change it besides gemrc in user profile (that only works for prompt env). Also can be added to client.rb as

rubygems_url "https://exmple.rubygems.mirror.com"

I if think, is needed to change rspecs for this.