### PR TITLE
adding client.d functionality for bootstrapping windows nodes

### DIFF
--- a/lib/chef/knife/bootstrap/windows-chef-client-msi.erb
+++ b/lib/chef/knife/bootstrap/windows-chef-client-msi.erb
@@ -241,6 +241,10 @@ mkdir <%= bootstrap_directory %>\ohai\hints
  <%= first_boot %>
 )
 
+<% unless client_d.empty? -%>
+mkdir <%= bootstrap_directory %>\client.d
+<%= client_d %>
+<% end -%>
+
 @echo Starting chef to bootstrap the node...
 <%= start_chef %>
-

--- a/lib/chef/knife/core/windows_bootstrap_context.rb
+++ b/lib/chef/knife/core/windows_bootstrap_context.rb
@@ -350,6 +350,27 @@ WGET_PS
           content
         end
 
+        def client_d_content
+          content = ""
+          if @chef_config[:client_d_dir] && File.exist?(@chef_config[:client_d_dir])
+            root = Pathname(@chef_config[:client_d_dir])
+            root.find do |f|
+              relative = f.relative_path_from(root)
+              if f != root
+                file_on_node = "#{bootstrap_directory}/#{relative}"
+                if f.directory?
+                  content << "mkdir #{file_on_node}\n"
+                else
+                  content << "> #{file_on_node} (\n" +
+                    f.read.gsub("'", "'\\\\''") + "\n)\n"
+                end
+              end
+            end
+          end
+          content
+        end
+
+
         def fallback_install_task_command
           # This command will be executed by schtasks.exe in the batch
           # code below. To handle tasks that contain arguments that

--- a/lib/chef/knife/core/windows_bootstrap_context.rb
+++ b/lib/chef/knife/core/windows_bootstrap_context.rb
@@ -357,12 +357,12 @@ WGET_PS
             root.find do |f|
               relative = f.relative_path_from(root)
               if f != root
-                file_on_node = "#{bootstrap_directory}/#{relative}"
+                file_on_node = "#{bootstrap_directory}/client.d/#{relative}"
                 if f.directory?
                   content << "mkdir #{file_on_node}\n"
                 else
                   content << "> #{file_on_node} (\n" +
-                    f.read.gsub("'", "'\\\\''") + "\n)\n"
+                    escape_and_echo(IO.read(File.expand_path(f))) + "\n)\n"
                 end
               end
             end


### PR DESCRIPTION
Starting in Chef 12.8 you can optionally have the contents of the `client.d` directory (or alternate path if preferred) from workstation to a new node during bootstrap, but for whatever reason this never made it into the knife-windows plugin.  `chef-client` already knows what to do with it once it's there, it's just a matter of getting the bits from point A to point B.  This branch adds that functionality.