### PR TITLE
Change the %PATH% env to use windows default values

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ gemfile: ci.gemfile
 
 env:
   - CHEF_VERSION="master"
-  - CHEF_VERSION="~> 12.0"
+  - CHEF_VERSION="~> 13.0"
 
 matrix:
   exclude:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ dist: trusty
 sudo: false
 
 rvm:
-  - 2.2.7
   - 2.3.4
   - 2.4.1
   - ruby-head
@@ -20,7 +19,7 @@ env:
 
 matrix:
   exclude:
-  - rvm: 2.2.7
+  - rvm: 2.3.4
     env: CHEF_VERSION="master"
   allow_failures:
     - rvm: ruby-head

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,8 +8,8 @@ environment:
   bundle_gemfile: ci.gemfile
 
   matrix:
-    - ruby_version: "23"
-      chef_version: "~> 12.0"
+    - ruby_version: "24"
+      chef_version: "~> 13.0"
 
     - ruby_version: "24"
       chef_version: "master"

--- a/ci.gemfile
+++ b/ci.gemfile
@@ -5,6 +5,7 @@ gemspec
 
 if ENV['CHEF_VERSION'] == 'master'
   gem 'chef', github: 'chef/chef'
+  gem 'ohai', github: 'chef/ohai'
 else
   gem 'chef', ENV['CHEF_VERSION']
 end

--- a/lib/chef/knife/core/windows_bootstrap_context.rb
+++ b/lib/chef/knife/core/windows_bootstrap_context.rb
@@ -170,7 +170,7 @@ CONFIG
 
         def start_chef
           bootstrap_environment_option = bootstrap_environment.nil? ? '' : " -E #{bootstrap_environment}"
-          start_chef = "SET \"PATH=%PATH%;C:\\ruby\\bin;C:\\opscode\\chef\\bin;C:\\opscode\\chef\\embedded\\bin\"\n"
+          start_chef = "SET \"PATH=%SystemRoot%\\system32;%SystemRoot%;%SystemRoot%\\System32\\Wbem;%SYSTEMROOT%\\System32\\WindowsPowerShell\\v1.0\\;C:\\ruby\\bin;C:\\opscode\\chef\\bin;C:\\opscode\\chef\\embedded\\bin\"\n"
           start_chef << "chef-client -c c:/chef/client.rb -j c:/chef/first-boot.json#{bootstrap_environment_option}\n"
         end
 

--- a/spec/assets/win_template_rendered_with_bootstrap_install_command.txt
+++ b/spec/assets/win_template_rendered_with_bootstrap_install_command.txt
@@ -215,6 +215,6 @@ echo.log_location       STDOUT
 ) 
 
 @echo Starting chef to bootstrap the node... 
-SET "PATH=%PATH%;C:\ruby\bin;C:\opscode\chef\bin;C:\opscode\chef\embedded\bin"
+SET "PATH=%SystemRoot%\system32;%SystemRoot%;%SystemRoot%\System32\Wbem;%SYSTEMROOT%\System32\WindowsPowerShell\v1.0\;C:\ruby\bin;C:\opscode\chef\bin;C:\opscode\chef\embedded\bin"
 chef-client -c c:/chef/client.rb -j c:/chef/first-boot.json
  

--- a/spec/assets/win_template_rendered_with_bootstrap_install_command_on_12_5_client.txt
+++ b/spec/assets/win_template_rendered_with_bootstrap_install_command_on_12_5_client.txt
@@ -215,6 +215,6 @@ echo.log_location       STDOUT
 ) 
 
 @echo Starting chef to bootstrap the node... 
-SET "PATH=%PATH%;C:\ruby\bin;C:\opscode\chef\bin;C:\opscode\chef\embedded\bin"
+SET "PATH=%SystemRoot%\system32;%SystemRoot%;%SystemRoot%\System32\Wbem;%SYSTEMROOT%\System32\WindowsPowerShell\v1.0\;C:\ruby\bin;C:\opscode\chef\bin;C:\opscode\chef\embedded\bin"
 chef-client -c c:/chef/client.rb -j c:/chef/first-boot.json
  

--- a/spec/assets/win_template_rendered_without_bootstrap_install_command.txt
+++ b/spec/assets/win_template_rendered_without_bootstrap_install_command.txt
@@ -327,6 +327,6 @@ echo.log_location       STDOUT
 ) 
 
 @echo Starting chef to bootstrap the node... 
-SET "PATH=%PATH%;C:\ruby\bin;C:\opscode\chef\bin;C:\opscode\chef\embedded\bin"
+SET "PATH=%SystemRoot%\system32;%SystemRoot%;%SystemRoot%\System32\Wbem;%SYSTEMROOT%\System32\WindowsPowerShell\v1.0\;C:\ruby\bin;C:\opscode\chef\bin;C:\opscode\chef\embedded\bin"
 chef-client -c c:/chef/client.rb -j c:/chef/first-boot.json
  

--- a/spec/assets/win_template_rendered_without_bootstrap_install_command_on_12_5_client.txt
+++ b/spec/assets/win_template_rendered_without_bootstrap_install_command_on_12_5_client.txt
@@ -327,6 +327,6 @@ echo.log_location       STDOUT
 ) 
 
 @echo Starting chef to bootstrap the node... 
-SET "PATH=%PATH%;C:\ruby\bin;C:\opscode\chef\bin;C:\opscode\chef\embedded\bin"
+SET "PATH=%SystemRoot%\system32;%SystemRoot%;%SystemRoot%\System32\Wbem;%SYSTEMROOT%\System32\WindowsPowerShell\v1.0\;C:\ruby\bin;C:\opscode\chef\bin;C:\opscode\chef\embedded\bin"
 chef-client -c c:/chef/client.rb -j c:/chef/first-boot.json
  

--- a/spec/assets/win_template_rendered_without_bootstrap_install_command_on_13_client.txt
+++ b/spec/assets/win_template_rendered_without_bootstrap_install_command_on_13_client.txt
@@ -327,6 +327,6 @@ echo.log_location       STDOUT
 ) 
 
 @echo Starting chef to bootstrap the node... 
-SET "PATH=%PATH%;C:\ruby\bin;C:\opscode\chef\bin;C:\opscode\chef\embedded\bin"
+SET "PATH=%SystemRoot%\system32;%SystemRoot%;%SystemRoot%\System32\Wbem;%SYSTEMROOT%\System32\WindowsPowerShell\v1.0\;C:\ruby\bin;C:\opscode\chef\bin;C:\opscode\chef\embedded\bin"
 chef-client -c c:/chef/client.rb -j c:/chef/first-boot.json
  

--- a/spec/functional/bootstrap_download_spec.rb
+++ b/spec/functional/bootstrap_download_spec.rb
@@ -167,7 +167,7 @@ describe "bootstrap_install_command functionality through WinRM protocol" do
       end
     end
 
-    context "when running chef-client 13.0 or greater", :chef_gte_13_only => true do
+    context "when running chef-client 13.0 or greater", :chef_gte_13_only => true, :chef_lt_14_only => true do
       let(:template_13_output) { sample_data('win_template_rendered_without_bootstrap_install_command_on_13_client.txt') }
       it "bootstrap_install_command option is not rendered in the windows-chef-client-msi.erb template as its value is nil"  do
         expect(bootstrap.send(:render_template,@template_input)).to eq(
@@ -189,7 +189,7 @@ describe "bootstrap_install_command functionality through WinRM protocol" do
         @template_output)
     end
 
-    context "when running chef-client 12.5.0 or greater", :chef_gte_12_5_only => true do
+    context "when running chef-client 12.5.0 or greater", :chef_gte_12_5_only => true, :chef_lt_14_only => true  do
       let(:template_12_5_output) { sample_data('win_template_rendered_with_bootstrap_install_command_on_12_5_client.txt') }
       it "bootstrap_install_command option is rendered in the windows-chef-client-msi.erb template" do
         expect(bootstrap.send(:render_template,@template_input)).to eq(

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -79,6 +79,10 @@ def chef_lt_14?
   Gem::Version.new(Chef::VERSION) < Gem::Version.new('14')
 end
 
+def chef_gte_14?
+  Gem::Version.new(Chef::VERSION) >= Gem::Version.new('14')
+end
+
 def sample_data(file_name)
   file =  File.expand_path(File.dirname("spec/assets/*"))+"/#{file_name}"
   File.read(file)
@@ -95,4 +99,5 @@ RSpec.configure do |config|
   config.filter_run_excluding :chef_lt_12_5_only => true unless chef_lt_12_5?
   config.filter_run_excluding :chef_lt_13_only => true unless chef_lt_13?
   config.filter_run_excluding :chef_lt_14_only => true unless chef_lt_14?
+  config.filter_run_excluding :chef_gte_14_only => true unless chef_gte_14?
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -75,6 +75,10 @@ def chef_lt_13?
   Gem::Version.new(Chef::VERSION) < Gem::Version.new('13')
 end
 
+def chef_lt_14?
+  Gem::Version.new(Chef::VERSION) < Gem::Version.new('14')
+end
+
 def sample_data(file_name)
   file =  File.expand_path(File.dirname("spec/assets/*"))+"/#{file_name}"
   File.read(file)
@@ -90,4 +94,5 @@ RSpec.configure do |config|
   config.filter_run_excluding :chef_gte_13_only => true unless chef_gte_13?
   config.filter_run_excluding :chef_lt_12_5_only => true unless chef_lt_12_5?
   config.filter_run_excluding :chef_lt_13_only => true unless chef_lt_13?
+  config.filter_run_excluding :chef_lt_14_only => true unless chef_lt_14?
 end

--- a/spec/unit/knife/bootstrap_options_spec.rb
+++ b/spec/unit/knife/bootstrap_options_spec.rb
@@ -44,7 +44,7 @@ expected: #{expected}
   end
 
   shared_examples 'compare_options' do
-    it 'contains the option flags' do
+    it 'contains the option flags', :chef_lt_14_only do
       opt_map.default_proc = proc { |map, key| key }
       filtered_keys = (win_bootstrap.options.keys - win_ignore).map! { |key| opt_map[key] }
 


### PR DESCRIPTION
Fixes issue when bootstrapping windows systems failing with the message: `The input line is too long.`.  

This is triggered by a "very" long `%PATH%` environment variable getting expanded at execution and causing the command being execute to become longer than the allowed size. 

We only need enough of the path set to be to run chef-client and doesn't persist to the system.

Signed-off-by: Will Fisher <wfisher@chef.io>