### PR TITLE
Detect if chef-client is already present

### DIFF
--- a/lib/chef/knife/bootstrap/windows-chef-client-msi.erb
+++ b/lib/chef/knife/bootstrap/windows-chef-client-msi.erb
@@ -101,7 +101,18 @@ goto Version6.2
   @set MACHINE_ARCH=x86_64
   IF "%PROCESSOR_ARCHITECTURE%"=="x86" IF not defined PROCESSOR_ARCHITEW6432 @set MACHINE_ARCH=i686
 <% end %>
-goto install
+goto chef_installed
+
+:chef_installed
+@echo Checking for existing chef installation
+WHERE chef-client >nul 2>nul
+If !ERRORLEVEL!==0 (
+  @echo Existing Chef installation detected, skipping download
+  goto key_create
+) else (
+  @echo No existing installation of chef detected
+  goto install
+)
 
 :install
 @rem If user has provided the custom installation command for chef-client then execute it
@@ -190,6 +201,7 @@ goto install
 
 <% end %>
 
+:key_create
 @endlocal
 
 @echo off
@@ -243,4 +255,3 @@ mkdir <%= bootstrap_directory %>\ohai\hints
 
 @echo Starting chef to bootstrap the node...
 <%= start_chef %>
-


### PR DESCRIPTION
Resolves issue #439 


If chef-client.bat is found on system, it prints line `"Chef is already installed, skipping download"` and skips the download. 

```
10.254.130.187 C:\Users\vagrant>IF "AMD64" == "x86" IF not defined PROCESSOR_ARCHITEW6432
10.254.130.187
10.254.130.187 C:\Users\vagrant>goto chef_installed
10.254.130.187 Checking for existing chef installation
10.254.130.187
10.254.130.187 C:\Users\vagrant>WHERE chef-client  1>nul 2>nul
10.254.130.187
10.254.130.187 C:\Users\vagrant>If !ERRORLEVEL! == 0 (
10.254.130.187
10.254.130.187  goto key_create
10.254.130.187 )  else (
10.254.130.187
10.254.130.187  goto install
10.254.130.187 )
10.254.130.187 "Chef is already installed, skipping download"
10.254.130.187 Writing validation key...
10.254.130.187 Validation key written.
10.254.130.187
10.254.130.187 C:\Users\vagrant>mkdir C:\chef\trusted_certs
10.254.130.187
10.254.130.187 C:\Users\vagrant>(
10.254.130.187 echo.-----BEGIN CERTIFICATE-----
```

If chef-client.bat is not found on system, it prints line `"No existing installation of chef detected"` and resumes as normal. 

```
0.254.130.122
10.254.130.122 )
10.254.130.122 Detected Windows Version 10.0 Build 14393
10.254.130.122 Warning: Unknown version of Windows, assuming default of Windows 2008r2
10.254.130.122
10.254.130.122 C:\Users\vagrant>goto architecture_select
10.254.130.122
10.254.130.122 C:\Users\vagrant>IF "AMD64" == "x86" IF not defined PROCESSOR_ARCHITEW6432
10.254.130.122
10.254.130.122 C:\Users\vagrant>goto chef_installed
10.254.130.122 Checking for existing chef installation
10.254.130.122
10.254.130.122 C:\Users\vagrant>WHERE chef-client2  1>nul 2>nul
10.254.130.122
10.254.130.122 C:\Users\vagrant>If !ERRORLEVEL! == 0 (
10.254.130.122
10.254.130.122  goto key_create
10.254.130.122 )  else (
10.254.130.122
10.254.130.122  goto install
10.254.130.122 )
10.254.130.122 "No existing installation of chef detected"
10.254.130.122 Checking for existing downloaded package at "C:\Users\vagrant\AppData\Local\Temp\chef-client-latest.msi"
10.254.130.122 No existing downloaded packages to delete.
10.254.130.122 Attempting to download client package using PowerShell if available...
10.254.130.122 powershell.exe -ExecutionPolicy Unrestricted -InputFormat None -NoProfile -NonInteractive -File  C:\chef\wget.ps1 "https://www.chef.io/chef/download?p=windows&pv=2008r2&m=x86_64&DownloadContext=PowerShell&v=12" "C:\Users\vagrant\AppData\Local\Temp\chef-client-latest.msi"
```

The core logic uses WHERE.exe which should be compatible even with extremely old shells. I've tested on windows 2012r2 and 2016. It should work all the way back to windows 2003

    WHERE chef-client >nul 2>nul