### PR TITLE
MSYS-831 : Fixed windows detection code for windows 2016, windows 2012r2

### DIFF
--- a/lib/chef/knife/bootstrap/windows-chef-client-msi.erb
+++ b/lib/chef/knife/bootstrap/windows-chef-client-msi.erb
@@ -1,6 +1,6 @@
 @rem
 @rem Author:: Seth Chisamore (<schisamo@chef.io>)
-@rem Copyright:: Copyright (c) 2011-2016 Chef Software, Inc.
+@rem Copyright:: Copyright (c) 2011-2017 Chef Software, Inc.
 @rem License:: Apache License, Version 2.0
 @rem
 @rem Licensed under the Apache License, Version 2.0 (the "License");
@@ -82,6 +82,7 @@ goto architecture_select
 @set MACHINE_OS=2012
 goto architecture_select
 
+@rem Currently Windows Server 2012 R2 is treated as equivalent to Windows Server 2012
 :Version6.3
 @set MACHINE_OS=2012r2
 goto architecture_select

--- a/lib/chef/knife/bootstrap/windows-chef-client-msi.erb
+++ b/lib/chef/knife/bootstrap/windows-chef-client-msi.erb
@@ -50,8 +50,8 @@
 
 @echo Detected Windows Version %WinMajor%.%WinMinor% Build %WinBuild%
 
-@set LATEST_OS_VERSION_MAJOR=6
-@set LATEST_OS_VERSION_MINOR=3
+@set LATEST_OS_VERSION_MAJOR=10
+@set LATEST_OS_VERSION_MINOR=1
 
 @if /i %WinMajor% GTR %LATEST_OS_VERSION_MAJOR% goto VersionUnknown
 @if /i %WinMajor% EQU %LATEST_OS_VERSION_MAJOR%  (
@@ -62,7 +62,7 @@ goto Version%WinMajor%.%WinMinor%
 
 :VersionUnknown
 @rem If this is an unknown version of windows set the default
-@set MACHINE_OS=2008r2
+@set MACHINE_OS=2012r2
 @echo Warning: Unknown version of Windows, assuming default of Windows %MACHINE_OS%
 goto architecture_select
 
@@ -82,9 +82,17 @@ goto architecture_select
 @set MACHINE_OS=2012
 goto architecture_select
 
-@rem Currently Windows Server 2012 R2 is treated as equivalent to Windows Server 2012
 :Version6.3
-goto Version6.2
+@set MACHINE_OS=2012r2
+goto architecture_select
+
+:Version10.0
+@set MACHINE_OS=2016
+goto architecture_select
+
+@rem Currently Windows Server 2016 R2 is treated as equivalent to Windows Server 2016
+:Version10.1
+goto Version10.0
 
 :architecture_select
 <% if knife_config[:architecture] %>

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,6 @@
 
 # Author:: Adam Edwards (<adamed@chef.io>)
-# Copyright:: Copyright (c) 2012-2016 Chef Software, Inc.
+# Copyright:: Copyright (c) 2012-2017 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -55,8 +55,37 @@ def windows2012?
   is_win2k12
 end
 
+def windows2016?
+  is_win2k16 = false
+
+  if  windows?
+    this_operating_system = WMI::Win32_OperatingSystem.find(:first)
+    os_version = this_operating_system.send('Version')
+
+    # The operating system version is a string in the following form
+    # that can be split into components based on the '.' delimiter:
+    # MajorVersionNumber.MinorVersionNumber.BuildNumber
+    os_version_components = os_version.split('.')
+
+    if os_version_components.length < 2
+      raise 'WMI returned a Windows version from Win32_OperatingSystem.Version ' +
+        'with an unexpected format. The Windows version could not be determined.'
+    end
+
+    # Windows 10.0 is Windows Server 2016, so test the major and
+    # minor version components
+    is_win2k16 = os_version_components[0] == '10' && os_version_components[1] == '0'
+  end
+
+  is_win2k16
+end
+
 def chef_lt_12_5?
   Gem::Version.new(Chef::VERSION) < Gem::Version.new('12.5')
+end
+
+def chef_gte_12?
+  Chef::VERSION.split('.').first.to_i >= 12
 end
 
 def chef_gte_12_5?


### PR DESCRIPTION
**Description**

- Added windows 2016 support.
- Added windows 2012r2 support.
- Added windows 10 support.
- If windows version is unknown made windows 2012r2 as default.

**Fixed issue**
Fixes https://github.com/chef/knife-windows/issues/441

**Testing**
Testing for other windows environment are completed.

Signed-off-by: piyushawasthi <piyush.awasthi@msystechnologies.com>