### PR TITLE
Remove previously deprecated bootstrap options

### DIFF
--- a/lib/chef/knife/bootstrap_windows_base.rb
+++ b/lib/chef/knife/bootstrap_windows_base.rb
@@ -70,29 +70,10 @@ class Chef
             :description => "Custom command to install chef-client",
             :proc        => Proc.new { |ic| Chef::Config[:knife][:bootstrap_install_command] = ic }
 
-          # DEPR: Remove this option in Chef 13
-          option :distro,
-            :short => "-d DISTRO",
-            :long => "--distro DISTRO",
-            :description => "Bootstrap a distro using a template. [DEPRECATED] Use -t / --bootstrap-template option instead.",
-            :proc        => Proc.new { |v|
-              Chef::Log.warn("[DEPRECATED] -d / --distro option is deprecated. Use --bootstrap-template option instead.")
-              v
-            }
-
           option :bootstrap_template,
             :short => "-t TEMPLATE",
             :long => "--bootstrap-template TEMPLATE",
             :description => "Bootstrap Chef using a built-in or custom template. Set to the full path of an erb template or use one of the built-in templates."
-
-          # DEPR: Remove this option in Chef 13
-          option :template_file,
-            :long => "--template-file TEMPLATE",
-            :description => "Full path to location of template to use. [DEPRECATED] Use -t / --bootstrap-template option instead.",
-            :proc        => Proc.new { |v|
-              Chef::Log.warn("[DEPRECATED] --template-file option is deprecated. Use --bootstrap-template option instead.")
-              v
-            }
 
           option :run_list,
             :short => "-r RUN_LIST",

--- a/lib/chef/knife/bootstrap_windows_ssh.rb
+++ b/lib/chef/knife/bootstrap_windows_ssh.rb
@@ -67,7 +67,11 @@ class Chef
 
       option :identity_file,
         :long => "--identity-file IDENTITY_FILE",
-        :description => "The SSH identity file used for authentication. [DEPRECATED] Use --ssh-identity-file instead."
+        :description => "The SSH identity file used for authentication. [DEPRECATED] Use --ssh-identity-file instead.",
+        :proc        => Proc.new { |v|
+          Chef::Log.warn("[DEPRECATED] --identity-file option is deprecated. Use --ssh-identity-file option instead.")
+          v
+        }
 
       option :ssh_identity_file,
         :short => "-i IDENTITY_FILE",

--- a/spec/unit/knife/bootstrap_options_spec.rb
+++ b/spec/unit/knife/bootstrap_options_spec.rb
@@ -102,8 +102,8 @@ expected: #{expected}
       :bootstrap_proxy_user,
       :bootstrap_proxy_pass,
       :bootstrap_preinstall_command,
-      :distro, # Deprecated - remove this when the flag is removed.
-      :template_file, # Deprecated - remove this when the flag is removed.
+      :distro, # Deprecated - remove this when we drop support for Chef 13.
+      :template_file, # Deprecated - remove this when we drop support for Chef 13.
     ]}
 
     # win_ignore: Options in windows that aren't relevant to core.
@@ -123,8 +123,6 @@ expected: #{expected}
       :winrm_codepage,
       :concurrency,
       :winrm_shell,
-      :distro, # Deprecated - remove this when the flag is removed.
-      :template_file, # Deprecated - remove this when the flag is removed.
     ] }
 
     include_examples 'compare_options'
@@ -154,17 +152,15 @@ expected: #{expected}
       :bootstrap_proxy_user,
       :bootstrap_proxy_pass,
       :bootstrap_preinstall_command,
-      :distro, # Deprecated - remove this when the flag is removed.
-      :template_file, # Deprecated - remove this when the flag is removed.
       :identity_file,
+      :distro, # Deprecated - remove this when we drop support for Chef 13.
+      :template_file, # Deprecated - remove this when we drop support for Chef 13.
     ]}
     # win_ignore: Options in windows that aren't relevant to core.
     let(:win_ignore) { [
       :auth_timeout,
       :install_as_service,
       :host_key_verification,  # Deprecated - remove this when the flag is removed.
-      :distro, # Deprecated - remove this when the flag is removed.
-      :template_file, # Deprecated - remove this when the flag is removed.
       :identity_file,
     ] }
 


### PR DESCRIPTION
These don't exist in Chef at this point and just fail. I also added a
proper deprecation warning to the other option so that users will see it
and move off that option.

Signed-off-by: Tim Smith <tsmith@chef.io>