### PR TITLE
Add fatal warnings for deprecation options

### DIFF
--- a/lib/chef/knife/bootstrap_windows_base.rb
+++ b/lib/chef/knife/bootstrap_windows_base.rb
@@ -70,13 +70,13 @@ class Chef
             :description => "Custom command to install chef-client",
             :proc        => Proc.new { |ic| Chef::Config[:knife][:bootstrap_install_command] = ic }
 
-          # DEPR: Remove this option in Chef 13
+          # @todo When we no longer support Chef 13 this can just go away
           option :distro,
             :short => "-d DISTRO",
             :long => "--distro DISTRO",
             :description => "Bootstrap a distro using a template. [DEPRECATED] Use -t / --bootstrap-template option instead.",
             :proc        => Proc.new { |v|
-              Chef::Log.warn("[DEPRECATED] -d / --distro option is deprecated. Use --bootstrap-template option instead.")
+              Chef::Log.fatal("[DEPRECATED] -d / --distro option is deprecated. Use --bootstrap-template option instead.")
               v
             }
 
@@ -85,12 +85,12 @@ class Chef
             :long => "--bootstrap-template TEMPLATE",
             :description => "Bootstrap Chef using a built-in or custom template. Set to the full path of an erb template or use one of the built-in templates."
 
-          # DEPR: Remove this option in Chef 13
+          # @todo When we no longer support Chef 13 this can just go away
           option :template_file,
             :long => "--template-file TEMPLATE",
             :description => "Full path to location of template to use. [DEPRECATED] Use -t / --bootstrap-template option instead.",
             :proc        => Proc.new { |v|
-              Chef::Log.warn("[DEPRECATED] --template-file option is deprecated. Use --bootstrap-template option instead.")
+              Chef::Log.fatal("[DEPRECATED] --template-file option is deprecated. Use --bootstrap-template option instead.")
               v
             }
 

--- a/lib/chef/knife/bootstrap_windows_ssh.rb
+++ b/lib/chef/knife/bootstrap_windows_ssh.rb
@@ -65,23 +65,28 @@ class Chef
         :description => "Enable SSH agent forwarding",
         :boolean => true
 
+      # @todo When we no longer support Chef 14 this can just go away
       option :identity_file,
         :long => "--identity-file IDENTITY_FILE",
-        :description => "The SSH identity file used for authentication. [DEPRECATED] Use --ssh-identity-file instead."
+        :description => "The SSH identity file used for authentication. [DEPRECATED] Use --ssh-identity-file instead.",
+        :proc        => Proc.new { |v|
+          Chef::Log.fatal("[DEPRECATED] --identify-file option is deprecated. Use --ssh-identity-template option instead.")
+          v
+        }
 
       option :ssh_identity_file,
         :short => "-i IDENTITY_FILE",
         :long => "--ssh-identity-file IDENTITY_FILE",
         :description => "The SSH identity file used for authentication"
 
-      # DEPR: Remove this option for the next release.
+      # @todo Remove this option for the next release.
       option :host_key_verification,
         :long => "--[no-]host-key-verify",
         :description => "Verify host key, enabled by default. [DEPRECATED] Use --host-key-verify option instead.",
         :boolean => true,
         :default => true,
         :proc => Proc.new { |key|
-          Chef::Log.warn("[DEPRECATED] --host-key-verification option is deprecated. Use --host-key-verify option instead.")
+          Chef::Log.fatal("[DEPRECATED] --host-key-verification option is deprecated. Use --host-key-verify option instead.")
           config[:host_key_verify] = key
         }
 


### PR DESCRIPTION
We want people to be forced to update to the new flags. Otherwise automated processes just keep going until we remove the flag and that gives people a really bad experience.

Signed-off-by: Tim Smith <tsmith@chef.io>