### PR TITLE
Removed deprecated host_key_verification, distro and template_file options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ gemfile: ci.gemfile
 env:
   - CHEF_VERSION="master"
   - CHEF_VERSION="~> 14.0"
-  - CHEF_VERSION="~> 13.0"
 
 matrix:
   exclude:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,7 @@ environment:
 
   matrix:
     - ruby_version: "24"
-      chef_version: "~> 13.0"
+      chef_version: "~> 14.0"
 
     - ruby_version: "25"
       chef_version: "master"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ environment:
     - ruby_version: "24"
       chef_version: "~> 13.0"
 
-    - ruby_version: "24"
+    - ruby_version: "25"
       chef_version: "master"
 
 clone_folder: c:\projects\knife-windows

--- a/lib/chef/knife/bootstrap_windows_base.rb
+++ b/lib/chef/knife/bootstrap_windows_base.rb
@@ -70,29 +70,10 @@ class Chef
             :description => "Custom command to install chef-client",
             :proc        => Proc.new { |ic| Chef::Config[:knife][:bootstrap_install_command] = ic }
 
-          # DEPR: Remove this option in Chef 13
-          option :distro,
-            :short => "-d DISTRO",
-            :long => "--distro DISTRO",
-            :description => "Bootstrap a distro using a template. [DEPRECATED] Use -t / --bootstrap-template option instead.",
-            :proc        => Proc.new { |v|
-              Chef::Log.warn("[DEPRECATED] -d / --distro option is deprecated. Use --bootstrap-template option instead.")
-              v
-            }
-
           option :bootstrap_template,
             :short => "-t TEMPLATE",
             :long => "--bootstrap-template TEMPLATE",
             :description => "Bootstrap Chef using a built-in or custom template. Set to the full path of an erb template or use one of the built-in templates."
-
-          # DEPR: Remove this option in Chef 13
-          option :template_file,
-            :long => "--template-file TEMPLATE",
-            :description => "Full path to location of template to use. [DEPRECATED] Use -t / --bootstrap-template option instead.",
-            :proc        => Proc.new { |v|
-              Chef::Log.warn("[DEPRECATED] --template-file option is deprecated. Use --bootstrap-template option instead.")
-              v
-            }
 
           option :run_list,
             :short => "-r RUN_LIST",
@@ -212,7 +193,7 @@ class Chef
         # The order here is important. We want to check if we have the new Chef 12 option is set first.
         # Knife cloud plugins unfortunately all set a default option for the :distro so it should be at
         # the end.
-        config[:bootstrap_template] || config[:template_file] || config[:distro] || default_bootstrap_template
+        config[:bootstrap_template] || default_bootstrap_template
       end
 
        # TODO: This should go away when CHEF-2193 is fixed
@@ -241,7 +222,7 @@ class Chef
         end
 
         unless template
-          ui.info("Can not find bootstrap definition for #{config[:distro]}")
+          ui.info("Can not find bootstrap definition for #{config[:bootstrap_template]}")
           raise Errno::ENOENT
         end
 

--- a/lib/chef/knife/bootstrap_windows_ssh.rb
+++ b/lib/chef/knife/bootstrap_windows_ssh.rb
@@ -74,17 +74,6 @@ class Chef
         :long => "--ssh-identity-file IDENTITY_FILE",
         :description => "The SSH identity file used for authentication"
 
-      # DEPR: Remove this option for the next release.
-      option :host_key_verification,
-        :long => "--[no-]host-key-verify",
-        :description => "Verify host key, enabled by default. [DEPRECATED] Use --host-key-verify option instead.",
-        :boolean => true,
-        :default => true,
-        :proc => Proc.new { |key|
-          Chef::Log.warn("[DEPRECATED] --host-key-verification option is deprecated. Use --host-key-verify option instead.")
-          config[:host_key_verify] = key
-        }
-
       option :host_key_verify,
         :long => "--[no-]host-key-verify",
         :description => "Verify host key, enabled by default.",

--- a/spec/unit/knife/bootstrap_options_spec.rb
+++ b/spec/unit/knife/bootstrap_options_spec.rb
@@ -156,6 +156,7 @@ expected: #{expected}
     let(:win_ignore) { [
       :auth_timeout,
       :install_as_service,
+      :identity_file,
     ] }
 
     include_examples 'compare_options'

--- a/spec/unit/knife/bootstrap_options_spec.rb
+++ b/spec/unit/knife/bootstrap_options_spec.rb
@@ -102,8 +102,6 @@ expected: #{expected}
       :bootstrap_proxy_user,
       :bootstrap_proxy_pass,
       :bootstrap_preinstall_command,
-      :distro, # Deprecated - remove this when the flag is removed.
-      :template_file, # Deprecated - remove this when the flag is removed.
     ]}
 
     # win_ignore: Options in windows that aren't relevant to core.
@@ -123,8 +121,6 @@ expected: #{expected}
       :winrm_codepage,
       :concurrency,
       :winrm_shell,
-      :distro, # Deprecated - remove this when the flag is removed.
-      :template_file, # Deprecated - remove this when the flag is removed.
     ] }
 
     include_examples 'compare_options'
@@ -154,17 +150,12 @@ expected: #{expected}
       :bootstrap_proxy_user,
       :bootstrap_proxy_pass,
       :bootstrap_preinstall_command,
-      :distro, # Deprecated - remove this when the flag is removed.
-      :template_file, # Deprecated - remove this when the flag is removed.
       :identity_file,
     ]}
     # win_ignore: Options in windows that aren't relevant to core.
     let(:win_ignore) { [
       :auth_timeout,
       :install_as_service,
-      :host_key_verification,  # Deprecated - remove this when the flag is removed.
-      :distro, # Deprecated - remove this when the flag is removed.
-      :template_file, # Deprecated - remove this when the flag is removed.
       :identity_file,
     ] }
 

--- a/spec/unit/knife/bootstrap_options_spec.rb
+++ b/spec/unit/knife/bootstrap_options_spec.rb
@@ -156,7 +156,6 @@ expected: #{expected}
     let(:win_ignore) { [
       :auth_timeout,
       :install_as_service,
-      :identity_file,
     ] }
 
     include_examples 'compare_options'

--- a/spec/unit/knife/bootstrap_windows_winrm_spec.rb
+++ b/spec/unit/knife/bootstrap_windows_winrm_spec.rb
@@ -45,7 +45,7 @@ describe Chef::Knife::BootstrapWindowsWinrm do
       host: "localhost"
     }
   end
-  let(:bootstrap) { Chef::Knife::BootstrapWindowsWinrm.new(['winrm', '-d', 'windows-chef-client-msi',  '-x', session_opts[:user], '-P', session_opts[:password], session_opts[:host]]) }
+  let(:bootstrap) { Chef::Knife::BootstrapWindowsWinrm.new(['winrm', '-t', 'windows-chef-client-msi',  '-x', session_opts[:user], '-P', session_opts[:password], session_opts[:host]]) }
   let(:session) { Chef::Knife::WinrmSession.new(session_opts) }
   let(:arch_session_result) {
     o = WinRM::Output.new


### PR DESCRIPTION
Signed-off-by: dheerajd-msys <dheeraj.dubey@msystechnologies.com>

## Descriptions

- Removed deprecated `--host-key-verification`, `--distro` & `--template-file` option.
- `--host-key-verify` is used now instead of `--host-key-verification`
- `--bootstrap-template-file` is used now instead of  `--distro` & `--template-file`

## Resolved Issue
Fixes https://github.com/chef/knife-windows/issues/469