### PR TITLE
Require Ruby 2.4 or later

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,9 @@ dist: xenial
 sudo: false
 
 rvm:
-  - 2.3.8
   - 2.4.5
   - 2.5.3
+  - 2.6.0
   - ruby-head
 
 before_install:
@@ -20,8 +20,6 @@ env:
 
 matrix:
   exclude:
-  - rvm: 2.3.8
-    env: CHEF_VERSION="master"
   - rvm: 2.3.8
     env: CHEF_VERSION="~> 14.0"
   - rvm: 2.4.5

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,6 @@ environment:
   matrix:
     - ruby_version: "24"
       chef_version: "~> 14.0"
-
     - ruby_version: "25"
       chef_version: "master"
 
@@ -26,7 +25,7 @@ install:
   - echo %PATH%
   - ruby --version
   - gem --version
-  - gem install bundler -v 1.11.2 --quiet --no-ri --no-rdoc
+  - gem install bundler --quiet --no-document || true
   - bundler --version
 
 build_script:

--- a/knife-windows.gemspec
+++ b/knife-windows.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.summary     = %q{Plugin that adds functionality to Chef's Knife CLI for configuring/interacting with nodes running Microsoft Windows}
   s.description = s.summary
 
-  s.required_ruby_version	= ">= 2.2"
+  s.required_ruby_version	= ">= 2.4"
   s.add_dependency "winrm", "~> 2.1"
   s.add_dependency "winrm-elevated", "~> 1.0"
 


### PR DESCRIPTION
We're requiring Chef 14, which is Ruby 2.4 or later.

Signed-off-by: Tim Smith <tsmith@chef.io>