### PR TITLE
fix log_level incosistency

### DIFF
--- a/lib/chef/knife/core/windows_bootstrap_context.rb
+++ b/lib/chef/knife/core/windows_bootstrap_context.rb
@@ -79,7 +79,7 @@ cache_options     ({:path => "c:/chef/cache/checksums", :skip_expires => true})
           if @chef_config[:config_log_level]
             client_rb << %Q{log_level :#{@chef_config[:config_log_level]}\n}
           else
-            client_rb << "log_level        :info\n"
+            client_rb << "log_level        :auto\n"
           end
 
           client_rb << "log_location       #{get_log_location}"


### PR DESCRIPTION
Signed-off-by: dheerajd-msys <dheeraj.dubey@msystechnologies.com>
## Description
Set `log_level` to `:auto` in `client.rb` in windows to make it consistent with other platform

## Issues Resolved
Fixes #231 