### PR TITLE
Require Chef Infra 15

### DIFF
--- a/knife-windows.gemspec
+++ b/knife-windows.gemspec
@@ -14,6 +14,7 @@ Gem::Specification.new do |s|
   s.description = s.summary
 
   s.required_ruby_version	= ">= 2.5.0"
+  s.add_dependency "chef", ">= 15.0"
   s.add_dependency "winrm", "~> 2.1"
   s.add_dependency "winrm-elevated", "~> 1.0"
 


### PR DESCRIPTION
knife-windows v3 removes `knife bootstrap windows winrm` and `knife
boostrap windows ssh` in favor of the functionality moved into core with
Chef Infra 15. We wouldn't want anyone using earlier versions of Chef to
pull in this release.

Signed-off-by: Bryan McLellan <btm@loftninjas.org>