### PR TITLE
Fix multiple session issue of concurrency flag

### DIFF
--- a/lib/chef/knife/winrm_knife_base.rb
+++ b/lib/chef/knife/winrm_knife_base.rb
@@ -118,15 +118,16 @@ class Chef
           def relay_winrm_command(command)
             Chef::Log.debug(command)
             @session_results = []
-
             queue = Queue.new
             @winrm_sessions.each { |s| queue << s }
-            number_of_session = config[:concurrency] ? locate_config_value(:concurrency) : @name_args[0].split(" ").count || queue.size
-            # These nils will kill the Threads once no more sessions are left
-            number_of_session.times { queue << nil }
+            num_sessions = locate_config_value(:concurrency)
+            num_targets = @winrm_sessions.length
+            num_sessions = (num_sessions.nil? || num_sessions == 0) ? num_targets : [num_sessions, num_targets].min
 
+            # These nils will kill the Threads once no more sessions are left
+            num_sessions.times { queue << nil }
             threads = []
-            number_of_session.times do
+            num_sessions.times do
               threads << Thread.new do
                 while session = queue.pop
                   run_command_in_thread(session, command)

--- a/lib/chef/knife/winrm_knife_base.rb
+++ b/lib/chef/knife/winrm_knife_base.rb
@@ -121,11 +121,12 @@ class Chef
 
             queue = Queue.new
             @winrm_sessions.each { |s| queue << s }
+            number_of_session = config[:concurrency] ? locate_config_value(:concurrency) : @name_args[0].split(" ").count || queue.size
             # These nils will kill the Threads once no more sessions are left
-            locate_config_value(:concurrency).times { queue << nil }
+            number_of_session.times { queue << nil }
 
             threads = []
-            locate_config_value(:concurrency).times do
+            number_of_session.times do
               threads << Thread.new do
                 while session = queue.pop
                   run_command_in_thread(session, command)

--- a/lib/chef/knife/winrm_shared_options.rb
+++ b/lib/chef/knife/winrm_shared_options.rb
@@ -43,7 +43,7 @@ class Chef
           option :concurrency,
             short: "-C NUM",
             long: "--concurrency NUM",
-            description: "The number of allowed concurrent connections",
+            description: "The number of allowed concurrent connections - default is number of hosts",
             proc: lambda { |o| o.to_i }
         end
       end

--- a/lib/chef/knife/winrm_shared_options.rb
+++ b/lib/chef/knife/winrm_shared_options.rb
@@ -44,7 +44,6 @@ class Chef
             short: "-C NUM",
             long: "--concurrency NUM",
             description: "The number of allowed concurrent connections",
-            default: 1,
             proc: lambda { |o| o.to_i }
         end
       end

--- a/spec/unit/knife/winrm_spec.rb
+++ b/spec/unit/knife/winrm_spec.rb
@@ -447,6 +447,22 @@ describe Chef::Knife::Winrm do
       expect { @winrm.run_with_pretty_exceptions }.to raise_error(SystemExit)
     end
 
+    context "impact of concurrency value" do
+      before(:each) do
+        allow(Chef::Knife::WinrmSession).to receive(:new).and_return(session)
+        @winrms = Chef::Knife::Winrm.new(['-C', '3', '-m', 'localhost', '-x', 'testuser', '-P', 'testpassword', '--winrm-authentication-protocol', 'basic', 'echo helloworld'])
+      end
+      it "create sessions to equal number of concurrent value if concurrent option is given" do
+        @winrms.config[:concurrency] = 1
+        allow(@winrms).to receive(:relay_winrm_command).and_return(true)
+        expect { @winrms.run_with_pretty_exceptions }.not_to raise_error
+      end
+      it "create sessions to equal number of IP's if concurrent option is not given" do
+        allow(@winrm).to receive(:relay_winrm_command).and_return(true)
+        expect { @winrm.run_with_pretty_exceptions }.not_to raise_error
+      end
+    end
+
     context "when winrm_authentication_protocol specified" do
       before do
         Chef::Config[:knife] = { winrm_transport: "plaintext" }

--- a/spec/unit/knife/winrm_spec.rb
+++ b/spec/unit/knife/winrm_spec.rb
@@ -447,22 +447,6 @@ describe Chef::Knife::Winrm do
       expect { @winrm.run_with_pretty_exceptions }.to raise_error(SystemExit)
     end
 
-    context "impact of concurrency value" do
-      before(:each) do
-        allow(Chef::Knife::WinrmSession).to receive(:new).and_return(session)
-        @winrms = Chef::Knife::Winrm.new(['-C', '3', '-m', 'localhost', '-x', 'testuser', '-P', 'testpassword', '--winrm-authentication-protocol', 'basic', 'echo helloworld'])
-      end
-      it "create sessions to equal number of concurrent value if concurrent option is given" do
-        @winrms.config[:concurrency] = 1
-        allow(@winrms).to receive(:relay_winrm_command).and_return(true)
-        expect { @winrms.run_with_pretty_exceptions }.not_to raise_error
-      end
-      it "create sessions to equal number of IP's if concurrent option is not given" do
-        allow(@winrm).to receive(:relay_winrm_command).and_return(true)
-        expect { @winrm.run_with_pretty_exceptions }.not_to raise_error
-      end
-    end
-
     context "when winrm_authentication_protocol specified" do
       before do
         Chef::Config[:knife] = { winrm_transport: "plaintext" }
@@ -508,6 +492,97 @@ describe Chef::Knife::Winrm do
         allow(Chef::Platform).to receive(:windows?).and_return(true)
         expect(@winrm.ui).to receive(:error)
         expect { @winrm.run }.to raise_error(SystemExit)
+      end
+    end
+  end
+
+  context "Impact of concurrency value when target nodes are 3" do
+    let(:winrm_user) { "testuser" }
+    let(:transport) { "plaintext" }
+    let(:password) { "testpassword" }
+    let(:protocol) { "basic" }
+    let(:knife_args) do
+      [
+        "-m", "localhost knownhost somehost",
+        "-x", winrm_user,
+        "-P", password,
+        "-w", transport,
+        "--winrm-authentication-protocol", protocol,
+        "echo helloworld"
+      ]
+    end
+    let(:winrm_connection) { Dummy::Connection.new }
+
+    subject { Chef::Knife::Winrm.new(knife_args) }
+
+    context "when concurrency limit is not set" do
+      it "spawns a number of connection threads equal to the number of target nodes" do
+        allow(subject).to receive(:run_command_in_thread).and_return("echo helloworld")
+        expect(Thread).to receive(:new).exactly(3).times.and_call_original
+        subject.configure_session
+        subject.relay_winrm_command(knife_args.last)
+      end
+    end
+
+    context "when concurrency limit is set" do
+      it "starts only the required number of threads when there are fewer targets than threads" do
+        knife_args.push("-C", "4")
+        allow(subject).to receive(:run_command_in_thread).and_return("echo helloworld")
+        expect(Thread).to receive(:new).exactly(3).times.and_call_original
+        subject.configure_session
+        subject.relay_winrm_command(knife_args.last)
+      end
+      it "starts only the requested number of threads when there are as many targets as threads" do
+        knife_args.push("-C", "3")
+        allow(subject).to receive(:run_command_in_thread).and_return("echo helloworld")
+        expect(Thread).to receive(:new).exactly(3).times.and_call_original
+        subject.configure_session
+        subject.relay_winrm_command(knife_args.last)
+      end
+      it "starts only the requested number of threads when there are more targets then threads" do
+        knife_args.push("-C", "2")
+        allow(subject).to receive(:run_command_in_thread).and_return("echo helloworld")
+        expect(Thread).to receive(:new).exactly(2).times.and_call_original
+        subject.configure_session
+        subject.relay_winrm_command(knife_args.last)
+      end
+    end
+
+    context "should call run_command_in_thread thrice when" do
+      it "concurrency not set" do
+        expect(subject).to receive(:run_command_in_thread).thrice
+        subject.configure_session
+        subject.relay_winrm_command(knife_args.last)
+      end
+      it "concurrency set to 4" do
+        knife_args.push("-C", "4")
+        expect(subject).to receive(:run_command_in_thread).thrice
+        subject.configure_session
+        subject.relay_winrm_command(knife_args.last)
+      end
+      it "concurrency set to 3" do
+        knife_args.push("-C", "3")
+        expect(subject).to receive(:run_command_in_thread).thrice
+        subject.configure_session
+        subject.relay_winrm_command(knife_args.last)
+      end
+      it "concurrency set to 2" do
+        knife_args.push("-C", "2")
+        expect(subject).to receive(:run_command_in_thread).thrice
+        subject.configure_session
+        subject.relay_winrm_command(knife_args.last)
+      end
+      it "concurrency set to 1" do
+        knife_args.push("-C", "1")
+        expect(subject).to receive(:run_command_in_thread).thrice
+        subject.configure_session
+        subject.relay_winrm_command(knife_args.last)
+      end
+      it "concurrency set to 0" do
+        knife_args.push("-C", "0")
+        expect(subject).to receive(:run_command_in_thread).thrice
+        subject.configure_session
+        subject.relay_winrm_command(knife_args.last)
       end
     end
   end


### PR DESCRIPTION
Signed-off-by: NAshwini <ashwini.nehate@msystechnologies.com>

### Description
Multiple servers can connect now using knife winrm command with and without providing an `--concurrency The number of allowed concurrent connection` option along with your `--manual-list QUERY is a space separated list of servers` option

### Issues Resolved
https://github.com/chef/knife-windows/issues/445
https://github.com/chef/knife-windows/issues/402

### Check List

- [*] New functionality includes tests
- [*] All tests pass
- [*] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG