### PR TITLE
Substitute require for require_relative

### DIFF
--- a/lib/chef/knife/bootstrap_windows_base.rb
+++ b/lib/chef/knife/bootstrap_windows_base.rb
@@ -19,7 +19,7 @@
 require 'chef/knife'
 require 'chef/knife/bootstrap'
 require 'chef/encrypted_data_bag_item'
-require 'chef/knife/knife_windows_base'
+require_relative 'knife_windows_base'
 require 'chef/util/path_helper'
 
 class Chef

--- a/lib/chef/knife/bootstrap_windows_ssh.rb
+++ b/lib/chef/knife/bootstrap_windows_ssh.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-require 'chef/knife/bootstrap_windows_base'
+require_relative 'bootstrap_windows_base'
 
 class Chef
   class Knife

--- a/lib/chef/knife/bootstrap_windows_winrm.rb
+++ b/lib/chef/knife/bootstrap_windows_winrm.rb
@@ -16,10 +16,10 @@
 # limitations under the License.
 #
 
-require 'chef/knife/bootstrap_windows_base'
-require 'chef/knife/winrm'
-require 'chef/knife/winrm_base'
-require 'chef/knife/winrm_knife_base'
+require_relative 'bootstrap_windows_base'
+require_relative 'winrm'
+require_relative 'winrm_base'
+require_relative 'winrm_knife_base'
 
 
 class Chef

--- a/lib/chef/knife/windows_cert_generate.rb
+++ b/lib/chef/knife/windows_cert_generate.rb
@@ -16,7 +16,7 @@
 #
 
 require 'chef/knife'
-require 'chef/knife/winrm_base'
+require_relative 'winrm_base'
 require 'openssl'
 require 'socket'
 

--- a/lib/chef/knife/windows_cert_install.rb
+++ b/lib/chef/knife/windows_cert_install.rb
@@ -16,7 +16,7 @@
 #
 
 require 'chef/knife'
-require 'chef/knife/winrm_base'
+require_relative 'winrm_base'
 
 class Chef
   class Knife

--- a/lib/chef/knife/windows_helper.rb
+++ b/lib/chef/knife/windows_helper.rb
@@ -17,10 +17,10 @@
 #
 
 require 'chef/knife'
-require 'chef/knife/winrm'
-require 'chef/knife/bootstrap_windows_ssh'
-require 'chef/knife/bootstrap_windows_winrm'
-require 'chef/knife/wsman_test'
+require_relative 'winrm'
+require_relative 'bootstrap_windows_ssh'
+require_relative 'bootstrap_windows_winrm'
+require_relative 'wsman_test'
 
 class Chef
   class Knife

--- a/lib/chef/knife/windows_listener_create.rb
+++ b/lib/chef/knife/windows_listener_create.rb
@@ -16,7 +16,7 @@
 #
 
 require 'chef/knife'
-require 'chef/knife/winrm_base'
+require_relative 'winrm_base'
 require 'openssl'
 
 class Chef

--- a/lib/chef/knife/winrm.rb
+++ b/lib/chef/knife/winrm.rb
@@ -17,12 +17,12 @@
 #
 
 require 'chef/knife'
-require 'chef/knife/winrm_knife_base'
-require 'chef/knife/windows_cert_generate'
-require 'chef/knife/windows_cert_install'
-require 'chef/knife/windows_listener_create'
-require 'chef/knife/winrm_session'
-require 'chef/knife/knife_windows_base'
+require_relative 'winrm_knife_base'
+require_relative 'windows_cert_generate'
+require_relative 'windows_cert_install'
+require_relative 'windows_listener_create'
+require_relative 'winrm_session'
+require_relative 'knife_windows_base'
 
 class Chef
   class Knife

--- a/lib/chef/knife/winrm_knife_base.rb
+++ b/lib/chef/knife/winrm_knife_base.rb
@@ -18,9 +18,9 @@
 
 
 require 'chef/knife'
-require 'chef/knife/winrm_base'
-require 'chef/knife/winrm_shared_options'
-require 'chef/knife/knife_windows_base'
+require_relative 'winrm_base'
+require_relative 'winrm_shared_options'
+require_relative 'knife_windows_base'
 
 class Chef
   class Knife

--- a/lib/chef/knife/wsman_test.rb
+++ b/lib/chef/knife/wsman_test.rb
@@ -18,8 +18,8 @@
 
 require 'httpclient'
 require 'chef/knife'
-require 'chef/knife/winrm_knife_base'
-require 'chef/knife/wsman_endpoint'
+require_relative 'winrm_knife_base'
+require_relative 'wsman_endpoint'
 
 class Chef
   class Knife


### PR DESCRIPTION
require_relative is significantly faster and should be used when available.

Signed-off-by: Tim Smith <tsmith@chef.io>