### PR TITLE
Require libraries only where we need them

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,7 +4,7 @@ Bundler::GemHelper.install_tasks
 begin
   require "rspec/core/rake_task"
 
-  task default: %i{unit_spec functional_spec style}
+  task default: %i{spec style}
 
   begin
     require "chefstyle"
@@ -17,13 +17,8 @@ begin
     puts "chefstyle gem is not installed. bundle install first to make sure all dependencies are installed."
   end
 
-  desc "Run all functional specs in spec directory"
-  RSpec::Core::RakeTask.new(:functional_spec) do |t|
-    t.pattern = "spec/functional/**/*_spec.rb"
-  end
-
   desc "Run all unit specs in spec directory"
-  RSpec::Core::RakeTask.new(:unit_spec) do |t|
+  RSpec::Core::RakeTask.new(:spec) do |t|
     t.pattern = "spec/unit/**/*_spec.rb"
   end
 

--- a/lib/chef/knife/bootstrap_windows_base.rb
+++ b/lib/chef/knife/bootstrap_windows_base.rb
@@ -17,8 +17,6 @@
 #
 
 require "chef/knife"
-require "chef/knife/bootstrap"
-require "chef/encrypted_data_bag_item"
 require_relative "knife_windows_base"
 require "chef/util/path_helper"
 
@@ -35,6 +33,8 @@ class Chef
         includer.class_eval do
 
           deps do
+            require "chef/knife/bootstrap"
+            require "chef/encrypted_data_bag_item"
             require "readline"
             require "chef/json_compat"
           end

--- a/lib/chef/knife/bootstrap_windows_ssh.rb
+++ b/lib/chef/knife/bootstrap_windows_ssh.rb
@@ -16,6 +16,7 @@
 # limitations under the License.
 #
 
+require "chef/knife"
 require_relative "bootstrap_windows_base"
 
 class Chef

--- a/lib/chef/knife/bootstrap_windows_winrm.rb
+++ b/lib/chef/knife/bootstrap_windows_winrm.rb
@@ -16,10 +16,10 @@
 # limitations under the License.
 #
 
+require "chef/knife"
 require_relative "bootstrap_windows_base"
-require_relative "winrm"
 require_relative "winrm_base"
-require_relative "winrm_knife_base"
+require_relative "winrm_knife_base" # WinrmCommandSharedFunctions
 
 class Chef
   class Knife
@@ -30,6 +30,7 @@ class Chef
       include Chef::Knife::WinrmCommandSharedFunctions
 
       deps do
+        require_relative "winrm"
         require "chef/json_compat"
         require "tempfile"
         Chef::Knife::Winrm.load_deps

--- a/lib/chef/knife/knife_windows_base.rb
+++ b/lib/chef/knife/knife_windows_base.rb
@@ -16,6 +16,8 @@
 # limitations under the License.
 #
 
+require "chef/knife"
+
 class Chef
   class Knife
     module KnifeWindowsBase

--- a/lib/chef/knife/windows_cert_generate.rb
+++ b/lib/chef/knife/windows_cert_generate.rb
@@ -17,8 +17,6 @@
 
 require "chef/knife"
 require_relative "winrm_base"
-require "openssl"
-require "socket"
 
 class Chef
   class Knife
@@ -27,6 +25,11 @@ class Chef
       attr_accessor :thumbprint, :hostname
 
       banner "knife windows cert generate FILE_PATH (options)"
+
+      deps do
+        require "openssl"
+        require "socket"
+      end
 
       option :hostname,
         short: "-H HOSTNAME",

--- a/lib/chef/knife/windows_helper.rb
+++ b/lib/chef/knife/windows_helper.rb
@@ -17,19 +17,13 @@
 #
 
 require "chef/knife"
-require_relative "winrm"
-require_relative "bootstrap_windows_ssh"
-require_relative "bootstrap_windows_winrm"
-require_relative "wsman_test"
-
 class Chef
   class Knife
     class WindowsHelper < Knife
-
-      banner "#{BootstrapWindowsWinrm.banner}\n" +
-        "#{BootstrapWindowsSsh.banner}\n" +
-        "#{Winrm.banner}\n" +
-        "#{WsmanTest.banner}"
+      banner "#{BootstrapWindowsWinrm.banner}\n" \
+             "#{BootstrapWindowsSsh.banner}\n" \
+             "#{Winrm.banner}\n" \
+             "#{WsmanTest.banner}"
     end
   end
 end

--- a/lib/chef/knife/windows_listener_create.rb
+++ b/lib/chef/knife/windows_listener_create.rb
@@ -17,11 +17,13 @@
 
 require "chef/knife"
 require_relative "winrm_base"
-require "openssl"
 
 class Chef
   class Knife
     class WindowsListenerCreate < Knife
+      deps do
+        require "openssl"
+      end
 
       banner "knife windows listener create (options)"
 

--- a/lib/chef/knife/winrm.rb
+++ b/lib/chef/knife/winrm.rb
@@ -17,10 +17,7 @@
 #
 
 require "chef/knife"
-require_relative "winrm_knife_base"
-require_relative "windows_cert_generate"
-require_relative "windows_cert_install"
-require_relative "windows_listener_create"
+require_relative "winrm_knife_base" # WinrmCommandSharedFunctions
 require_relative "winrm_session"
 require_relative "knife_windows_base"
 
@@ -32,6 +29,9 @@ class Chef
       include Chef::Knife::KnifeWindowsBase
 
       deps do
+        require_relative "windows_cert_generate"
+        require_relative "windows_cert_install"
+        require_relative "windows_listener_create"
         require "readline"
         require "chef/search/query"
       end

--- a/lib/chef/knife/winrm_base.rb
+++ b/lib/chef/knife/winrm_base.rb
@@ -17,8 +17,6 @@
 #
 
 require "chef/knife"
-require "chef/encrypted_data_bag_item"
-require "kconv"
 
 class Chef
   class Knife
@@ -34,6 +32,8 @@ class Chef
         includer.class_eval do
 
           deps do
+            require "chef/encrypted_data_bag_item"
+            require "kconv"
             require "readline"
             require "chef/json_compat"
           end

--- a/lib/chef/knife/winrm_session.rb
+++ b/lib/chef/knife/winrm_session.rb
@@ -16,6 +16,7 @@
 # limitations under the License.
 #
 
+require "chef/knife"
 require "chef/application"
 require "winrm"
 require "winrm-elevated"

--- a/lib/chef/knife/winrm_shared_options.rb
+++ b/lib/chef/knife/winrm_shared_options.rb
@@ -17,9 +17,6 @@
 #
 
 require "chef/knife"
-require "chef/encrypted_data_bag_item"
-require "kconv"
-
 class Chef
   class Knife
     module WinrmSharedOptions

--- a/lib/chef/knife/wsman_test.rb
+++ b/lib/chef/knife/wsman_test.rb
@@ -16,7 +16,6 @@
 # limitations under the License.
 #
 
-require "httpclient"
 require "chef/knife"
 require_relative "winrm_knife_base"
 require_relative "wsman_endpoint"
@@ -28,6 +27,7 @@ class Chef
       include Chef::Knife::WinrmCommandSharedFunctions
 
       deps do
+        require "httpclient"
         require "chef/search/query"
       end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,9 +17,6 @@
 # limitations under the License.
 #
 
-require_relative "../lib/chef/knife/winrm"
-require_relative "../lib/chef/knife/wsman_test"
-
 def sample_data(file_name)
   file = File.expand_path(File.dirname("spec/assets/*")) + "/#{file_name}"
   File.read(file)

--- a/spec/unit/knife/windows_cert_generate_spec.rb
+++ b/spec/unit/knife/windows_cert_generate_spec.rb
@@ -18,7 +18,6 @@
 
 require "spec_helper"
 require "chef/knife/windows_cert_generate"
-require "openssl"
 
 describe Chef::Knife::WindowsCertGenerate do
   before(:all) do

--- a/spec/unit/knife/winrm_session_spec.rb
+++ b/spec/unit/knife/winrm_session_spec.rb
@@ -17,6 +17,7 @@
 #
 
 require "spec_helper"
+require_relative "../../../lib/chef/knife/winrm"
 require "dummy_winrm_connection"
 
 Chef::Knife::Winrm.load_deps

--- a/spec/unit/knife/winrm_spec.rb
+++ b/spec/unit/knife/winrm_spec.rb
@@ -17,6 +17,7 @@
 #
 
 require "spec_helper"
+require_relative "../../../lib/chef/knife/winrm"
 require "dummy_winrm_connection"
 
 Chef::Knife::Winrm.load_deps

--- a/spec/unit/knife/wsman_test_spec.rb
+++ b/spec/unit/knife/wsman_test_spec.rb
@@ -17,6 +17,7 @@
 #
 
 require "spec_helper"
+require_relative "../../../lib/chef/knife/wsman_test"
 
 describe Chef::Knife::WsmanTest do
   let(:http_client_mock) { HTTPClient.new }


### PR DESCRIPTION
Make sure things like the knife deps is everywhere, but don't depend on things we don't need and lazily depend on whatever we can.

WARNING: This is going to need a good deal of hand testing before it's ready for prime time since the spec coverage here needs some work.

Signed-off-by: Tim Smith <tsmith@chef.io>