### PR TITLE
Lazy load winrm_session for speedup

### DIFF
--- a/lib/chef/knife/winrm.rb
+++ b/lib/chef/knife/winrm.rb
@@ -18,7 +18,6 @@
 
 require "chef/knife"
 require_relative "winrm_knife_base" # WinrmCommandSharedFunctions
-require_relative "winrm_session"
 require_relative "knife_windows_base"
 
 class Chef
@@ -32,6 +31,7 @@ class Chef
         require_relative "windows_cert_generate"
         require_relative "windows_cert_install"
         require_relative "windows_listener_create"
+        require_relative "winrm_session"
         require "readline"
         require "chef/search/query"
       end


### PR DESCRIPTION
This is the longest loading knife plugin on my mac and adds .3 seconds
to every knife command run on the system

Signed-off-by: Tim Smith <tsmith@chef.io>