### PR TITLE
Optimize our requires

### DIFF
--- a/lib/chef/knife/windows_cert_generate.rb
+++ b/lib/chef/knife/windows_cert_generate.rb
@@ -27,8 +27,8 @@ class Chef
       banner "knife windows cert generate FILE_PATH (options)"
 
       deps do
-        require "openssl"
-        require "socket"
+        require "openssl" unless defined?(OpenSSL)
+        require "socket" unless defined?(Socket)
       end
 
       option :hostname,

--- a/lib/chef/knife/windows_listener_create.rb
+++ b/lib/chef/knife/windows_listener_create.rb
@@ -22,7 +22,7 @@ class Chef
   class Knife
     class WindowsListenerCreate < Knife
       deps do
-        require "openssl"
+        require "openssl" unless defined?(OpenSSL)
       end
 
       banner "knife windows listener create (options)"


### PR DESCRIPTION
Avoid requiring things that are already defined. Rubygems is very slow at traversing the filesystem.

Signed-off-by: Tim Smith <tsmith@chef.io>