### PR TITLE
autoload winrm

### DIFF
--- a/lib/chef/knife/helpers/winrm_session.rb
+++ b/lib/chef/knife/helpers/winrm_session.rb
@@ -18,8 +18,7 @@
 
 require "chef/knife"
 require "chef/application"
-require "winrm"
-require "winrm-elevated"
+autoload :WinRM, "winrm-elevated"
 
 class Chef
   class Knife


### PR DESCRIPTION
This shaves another 2 seconds off of loading knife commands. We just need `winrm-elevated` which then requires `winrm`.

Signed-off-by: mwrock <matt@mattwrock.com>
