### PR TITLE
Support external testing

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -11,14 +11,6 @@ expeditor:
 
 steps:
 
-- label: run-lint-and-specs-ruby-2.6
-  command:
-    - .expeditor/run_linux_tests.sh rake
-  expeditor:
-    executor:
-      docker:
-        image: ruby:2.6-buster
-
 - label: run-lint-and-specs-ruby-2.7
   command:
     - .expeditor/run_linux_tests.sh rake
@@ -26,6 +18,14 @@ steps:
     executor:
       docker:
         image: ruby:2.7-buster
+
+- label: run-lint-and-specs-ruby-3.0
+  command:
+    - .expeditor/run_linux_tests.sh rake
+  expeditor:
+    executor:
+      docker:
+        image: ruby:3.0-buster
 
 - label: run-lint-and-specs-windows
   command:

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,15 @@ source "https://rubygems.org"
 # Specify the gem's dependencies in knife-windows.gemspec
 gemspec
 
+# Necessary for the external tests in https://github.com/chef/chef
+if ENV["GEMFILE_MOD"]
+  puts "GEMFILE_MOD: #{ENV["GEMFILE_MOD"]}"
+  instance_eval(ENV["GEMFILE_MOD"])
+else
+  gem "chef", git: "https://github.com/chef/chef"
+  gem "ohai", git: "https://github.com/chef/ohai"
+end
+
 group :test do
   gem "rspec", "~> 3.0"
   gem "rake"


### PR DESCRIPTION
The chef/chef repo needs to inject itself via ENV vars into the
Gemfile of this repo

(We have been uselessly testing knife-windows against the last release of chef/chef on every PR
in that repo instead of testing against the submitted code)