### PR TITLE
CHEF-1917 Fixed the knife-windows verify test failure

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -11,22 +11,13 @@ expeditor:
 
 steps:
 
-- label: run-lint-and-specs-ruby-2.7
+- label: run-lint-and-specs-ruby-3.1
   command:
     - .expeditor/run_linux_tests.sh rake
   expeditor:
     executor:
       docker:
-        image: ruby:2.7-buster
-
-- label: run-lint-and-specs-ruby-3.0
-  command:
-    - .expeditor/run_linux_tests.sh rake
-  expeditor:
-    executor:
-      docker:
-        image: ruby:3.0-buster
-
+        image: ruby:3.1-buster
 - label: run-lint-and-specs-windows
   command:
     - gem install chef-utils
@@ -36,4 +27,4 @@ steps:
     executor:
       docker:
         host_os: windows
-        image: rubydistros/windows-2019:3.0
+        image: rubydistros/windows-2019:3.1

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,6 @@ if ENV["GEMFILE_MOD"]
   puts "GEMFILE_MOD: #{ENV["GEMFILE_MOD"]}"
   instance_eval(ENV["GEMFILE_MOD"])
 else
-  gem "chef", git: "https://github.com/chef/chef", branch: "main"
   gem "ohai", git: "https://github.com/chef/ohai", branch: "main"
   gem "knife"
 end

--- a/knife-windows.gemspec
+++ b/knife-windows.gemspec
@@ -12,8 +12,8 @@ Gem::Specification.new do |s|
   s.summary     = %q{Plugin that adds functionality to Chef Infra's Knife CLI for configuring/interacting with nodes running Microsoft Windows}
   s.description = s.summary
 
-  s.required_ruby_version = ">= 2.7.0"
-  s.add_dependency "chef", ">= 15.11"
+  s.required_ruby_version = ">= 3.1"
+  s.add_dependency "chef", ">= 18.2"
   s.add_dependency "winrm", "~> 2.1"
   s.add_dependency "winrm-elevated", "~> 1.0"
 


### PR DESCRIPTION

## Description
updated ruby version to 3.1 and removed 2.7 and 3.0 ruby verify pipeline as the latest chef 18.2.7 supports ruby >= 3.1

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
