### PR TITLE
Add dependency to pin rexml at <= 3.3.1 as latest versions throw exception

### DIFF
--- a/knife-windows.gemspec
+++ b/knife-windows.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = ">= 2.7", "< 3.1"
   s.add_dependency "chef", "~> 17.10"
   s.add_dependency "winrm", "~> 2.1"
+  s.add_dependency "rexml", "<= 3.3.1" # A non xml string parsing will throw an error 3.3.2 onward. https://github.com/ruby/rexml/issues/180
   s.add_dependency "winrm-elevated", "~> 1.0"
 
   s.add_development_dependency "pry"


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
The specs currently throw following error
```

Failure/Error: doc = REXML::Document.new(response.body)
--
  |  
  | REXML::ParseException:
  | Malformed XML: Content at the start of the document (got 'I am invalid')
  | Line: 1
  | Position: 12
  | Last 80 unconsumed characters:
  | # /usr/local/bundle/gems/rexml-3.3.4/lib/rexml/parsers/baseparser.rb:488:in `pull_event'
  | # /usr/local/bundle/gems/rexml-3.3.4/lib/rexml/parsers/baseparser.rb:219:in `pull'
  | # /usr/local/bundle/gems/rexml-3.3.4/lib/rexml/parsers/treeparser.rb:22:in `parse'
  | # /usr/local/bundle/gems/rexml-3.3.4/lib/rexml/document.rb:448:in `build'
  | # /usr/local/bundle/gems/rexml-3.3.4/lib/rexml/document.rb:101:in `initialize'
  | # ./lib/chef/knife/wsman_test.rb:101:in `new'
  | # ./lib/chef/knife/wsman_test.rb:101:in `parse_response'
  | # ./lib/chef/knife/wsman_test.rb:59:in `block in verify_wsman_accessiblity_for_nodes'
  | # ./lib/chef/knife/wsman_test.rb:49:in `each'
  | # ./lib/chef/knife/wsman_test.rb:49:in `verify_wsman_accessiblity_for_nodes'
  | # ./lib/chef/knife/wsman_test.rb:42:in `run'
  | # ./spec/unit/knife/wsman_test_spec.rb:67:in `block (5 levels) in <top (required)>'
  | # ./spec/spec_helper.rb:38:in `block (2 levels) in <top (required)>'


```
This is seen at verify pipeline at chef/chef (Could have been seen here as well but apparently the verify pipeline here isn't getting triggered since ages, need to fix that)
Chef 17 : https://buildkite.com/chef-oss/chef-chef-chef-17-verify/builds/2776#01912e84-08d1-4526-a869-8549d9e1b0dd/193-1399
This started happening since rexml 3.3.2 onward. The earlier rexml versions did not throw malformed xml error if a string is passed (i.e non xml value is passed). So we put a pin to not pull that in since the gem uses rexml parsing on strings as well.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
