### PR TITLE
Handle REXML exception

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,10 @@ if ENV["GEMFILE_MOD"]
   puts "GEMFILE_MOD: #{ENV["GEMFILE_MOD"]}"
   instance_eval(ENV["GEMFILE_MOD"])
 else
-  gem "ohai", git: "https://github.com/chef/ohai", branch: "main"
+  # changed to 18-stable given that it's the newest compatible with
+  # the latest knife (and knife is embedded in chef so can't just point at
+  # GitHub)
+  gem "ohai", git: "https://github.com/chef/ohai", branch: "18-stable"
   gem "knife"
 end
 

--- a/lib/chef/knife/wsman_test.rb
+++ b/lib/chef/knife/wsman_test.rb
@@ -98,12 +98,16 @@ class Chef
         if response.nil? || response.status_code != 200
           output_object.error_message = "No valid WSMan endoint listening at #{node.endpoint}."
         else
-          doc = REXML::Document.new(response.body)
-          output_object.protocol_version = search_xpath(doc, "//wsmid:ProtocolVersion")
-          output_object.product_version  = search_xpath(doc, "//wsmid:ProductVersion")
-          output_object.product_vendor = search_xpath(doc, "//wsmid:ProductVendor")
-          if output_object.protocol_version.to_s.strip.length == 0
-            output_object.error_message = "Endpoint #{node.endpoint} on #{node.host} does not appear to be a WSMAN endpoint. Response body was #{response.body}"
+          begin
+            doc = REXML::Document.new(response.body)
+            output_object.protocol_version = search_xpath(doc, "//wsmid:ProtocolVersion")
+            output_object.product_version  = search_xpath(doc, "//wsmid:ProductVersion")
+            output_object.product_vendor = search_xpath(doc, "//wsmid:ProductVendor")
+            if output_object.protocol_version.to_s.strip.length == 0
+              output_object.error_message = "Endpoint #{node.endpoint} on #{node.host} does not appear to be a WSMAN endpoint. Response body was #{response.body}"
+            end
+          rescue REXML::ParseException => e
+            output_object.error_message = e.message
           end
         end
         output_object


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
ReXML 3.3.2 broke the knife-windows functionality by [adding a `REXML::ParseException` `raise`](https://github.com/ruby/rexml/compare/v3.2.6...v3.3.4#diff-f8c7cdefc29090ed525a2be70411ce741d4124853cf6425db7d18a6ea3bb9bb3R233)

Handle that exception and return an error message as before.

Supercedes #527, leaving #526 with the old behavior and a ReXML pin to v3.2.6

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
