### PR TITLE
Updating rxml dependency

### DIFF
--- a/knife-windows.gemspec
+++ b/knife-windows.gemspec
@@ -12,9 +12,10 @@ Gem::Specification.new do |s|
   s.summary     = %q{Plugin that adds functionality to Chef Infra's Knife CLI for configuring/interacting with nodes running Microsoft Windows}
   s.description = s.summary
 
-  s.required_ruby_version = ">= 2.7", "< 3.1"
-  s.add_dependency "chef", "~> 17.10"
+  s.required_ruby_version = ">= 3.0", "< 3.1"
+  s.add_dependency "chef", "~> 17.10.122"
   s.add_dependency "winrm", "~> 2.1"
+  s.add_dependency "rexml", "<= 3.3.1" # A non xml string parsing will throw an error 3.3.2 onward. https://github.com/ruby/rexml/issues/180
   s.add_dependency "winrm-elevated", "~> 1.0"
 
   s.add_development_dependency "pry"


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
An update to REXML breaks the wsman testing. Here we pin the older version which works for Chef-17. 

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
