### PR TITLE
CHEF-25786 - Remove SLA text from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,6 @@ Knife Windows Plugin
 
 **Umbrella Project**: [Knife](https://github.com/chef/chef-oss-practices/blob/master/projects/knife.md)
 
-**Project State**: [Active](https://github.com/chef/chef-oss-practices/blob/master/repo-management/repo-states.md#active)
-
-**Issues [Response Time Maximum](https://github.com/chef/chef-oss-practices/blob/master/repo-management/repo-states.md)**: 14 days
-
-**Pull Request [Response Time Maximum](https://github.com/chef/chef-oss-practices/blob/master/repo-management/repo-states.md)**: 14 days
-
 This plugin adds additional functionality to the Chef Knife CLI tool for
 configuring / interacting with nodes running Microsoft Windows:
 


### PR DESCRIPTION
## Summary

This PR removes outdated Service Level Agreement (SLA) text from the README.md file as part of the 2025 Repo Standardization Initiative.

## Changes

- Removes Project State information
- Removes Issues Response Time Maximum commitment  
- Removes Pull Request Response Time Maximum commitment

These SLA commitments are no longer accurate or supported by Progress Chef and were misleading to users expecting specific response times.

## References

- https://github.com/chef-boneyard/oss-repo-standardization-2025